### PR TITLE
1.5.3

### DIFF
--- a/assets/css/klarna-payments-admin.css
+++ b/assets/css/klarna-payments-admin.css
@@ -10,7 +10,7 @@
 }
 
 /* Banner */
-#klarna-banner {
+#klarna-kp-banner {
 	background-image: url("../img/admin-banner.jpg");
 	background-position: center center;
 	background-size: 100% auto;
@@ -24,7 +24,7 @@
 	height: 20px;
 }
 
-#klarna-banner > div {
+#klarna-kp-banner > div {
 	text-align: center;
 	padding: 0 60px;
 	-webkit-box-sizing: border-box;
@@ -33,7 +33,7 @@
 	font-family: Klarna, sans-serif;
 }
 
-#klarna-banner h1 {
+#klarna-kp-banner h1 {
 	font-size: 32px;
 	line-height: 1.2;
 	font-weight: bold;
@@ -42,7 +42,7 @@
 	margin-top: 0;
 }
 
-#klarna-banner p {
+#klarna-kp-banner p {
 	margin-bottom: 1em;
 	font-size: 14px;
 	letter-spacing: -0.2px;
@@ -68,18 +68,28 @@ a.kb-button {
 	-moz-box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
 	box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
 }
+.kb-kp-dismiss {
+	position: absolute;
+	top: 5px;
+	right: 5px;
+}
+.kb-kp-dismiss:hover {
+	color: #eb6f93;
+	cursor: pointer;
+}
+
 
 @media (min-width: 800px) {
-	#klarna-banner {
+	#klarna-kp-banner {
 		overflow: hidden;
 	}
 
-	#klarna-banner > div {
+	#klarna-kp-banner > div {
 		float: left;
 		width: 50%;
 	}
 
-	#klarna-banner > div > * {
+	#klarna-kp-banner > div > * {
 		margin-left: auto;
 		margin-right: auto;
 		max-width: 500px;
@@ -87,7 +97,7 @@ a.kb-button {
 }
 
 @media (max-width: 799px) {
-	#klarna-banner > div {
+	#klarna-kp-banner > div {
 		margin-bottom: 40px;
 	}
 }

--- a/includes/class-wc-gateway-klarna-payments.php
+++ b/includes/class-wc-gateway-klarna-payments.php
@@ -564,6 +564,7 @@ class WC_Gateway_Klarna_Payments extends WC_Payment_Gateway {
 			if ( is_wp_error( $create_response ) ) { // Create failed, make Klarna Payments unavailable.
 				$this->session_error = $create_response;
 				WC_Klarna_Payments::log( 'Could not update Klarna session. Response: ' . stripslashes_deep( json_encode( $create_response ) ) );
+				WC_Klarna_Payments::log( 'Posted request args: ' . stripslashes_deep( json_encode( $request_args ) ) );
 				wc_add_notice( 'Could not create Klarna session, please refresh the page to try again', 'error' );
 				$this->unset_session_values();
 			} else { // Store session ID and client token in WC session.

--- a/includes/class-wc-gateway-klarna-payments.php
+++ b/includes/class-wc-gateway-klarna-payments.php
@@ -945,7 +945,7 @@ class WC_Gateway_Klarna_Payments extends WC_Payment_Gateway {
 				'Content-Type'  => 'application/json',
 			),
 			'user-agent' => apply_filters( 'http_headers_useragent', 'WordPress/' . get_bloginfo( 'version' ) . '; ' . get_bloginfo( 'url' ) ) . ' - KP:' . WC_KLARNA_PAYMENTS_VERSION . ' - PHP Version: ' . phpversion() . ' - Krokedil',
-			'body'       => wp_json_encode( array(
+			'body'       => wp_json_encode( apply_filters('kp_wc_api_request_args', array(
 				'purchase_country'    => $this->klarna_country,
 				'purchase_currency'   => get_woocommerce_currency(),
 				'locale'              => $this->get_locale_for_klarna_country(),
@@ -959,7 +959,7 @@ class WC_Gateway_Klarna_Payments extends WC_Payment_Gateway {
 					'confirmation' => $order->get_checkout_order_received_url(),
 					'notification' => get_home_url() . '/wc-api/WC_Gateway_Klarna_Payments/?order_id=' . $order_id,
 				),
-			) ),
+			), $order, $posted_data ) ),
 		);
 
 		$response = wp_safe_remote_post( $request_url, $request_args );

--- a/includes/class-wc-gateway-klarna-payments.php
+++ b/includes/class-wc-gateway-klarna-payments.php
@@ -422,6 +422,10 @@ class WC_Gateway_Klarna_Payments extends WC_Payment_Gateway {
 			return false;
 		}
 
+		if ( is_wc_endpoint_url( 'order-pay' ) ) {
+			return false;
+		}
+
 		$this->set_klarna_country();
 		$this->set_credentials();
 

--- a/includes/class-wc-klarna-banners.php
+++ b/includes/class-wc-klarna-banners.php
@@ -15,6 +15,8 @@ if ( ! class_exists( 'WC_Klarna_Banners_KP' ) ) {
 		public function __construct() {
 			add_action( 'in_admin_header', array( $this, 'klarna_banner' ) );
 			add_action( 'admin_enqueue_scripts', array( $this, 'load_admin_css' ) );
+			add_action( 'wp_ajax_hide_klarna_kp_banner', array( $this, 'hide_klarna_kp_banner' ) );
+			add_action( 'wp_ajax_nopriv_hide_klarna_kp_banner', array( $this, 'hide_klarna_kp_banner' ) );
 		}
 
 		/**
@@ -68,10 +70,10 @@ if ( ! class_exists( 'WC_Klarna_Banners_KP' ) ) {
 				$show_banner = true;
 			}
 
-			if ( $show_banner ) {
+			if ( $show_banner  && false === get_transient( 'klarna_kp_hide_banner' ) ) {
 				?>
 				<div id="kb-spacer"></div>
-				<div id="klarna-banner">
+				<div id="klarna-kp-banner">
 					<div id="kb-left">
 						<h1>Go live</h1>
 						<p>Before you can start to sell with Klarna you need your store to be approved by Klarna. When the installation is done and you are ready to go live, Klarna will need to verify the integration. Then you can go live with your store! If you wish to switch Klarna products then you’ll need the Klarna team to approve your store again.</p>
@@ -89,7 +91,29 @@ if ( ! class_exists( 'WC_Klarna_Banners_KP' ) ) {
 					<img id="kb-image"
 						 src="<?php echo esc_url( WC_KLARNA_PAYMENTS_PLUGIN_URL ); ?>/assets/img/klarna_logo_white.png"
 						 alt="Klarna logo" width="110"/>
+						 <span class="kb-kp-dismiss dashicons dashicons-dismiss"></span>
 				</div>
+
+				<script type="text/javascript">
+					jQuery(document).ready(function($){
+
+						jQuery('.kb-kp-dismiss').click(function(){
+							jQuery('#klarna-kp-banner').slideUp();
+							jQuery.post(
+								ajaxurl,
+								{
+									action		: 'hide_klarna_kp_banner',
+									_wpnonce	: '<?php echo wp_create_nonce('hide-klarna-kp-banner'); ?>',
+								},
+								function(response){
+									console.log('Success hide kp banner');
+									
+								}
+							);
+											
+						});
+					});
+					</script>
 				<?php
 			}
 		}
@@ -125,6 +149,15 @@ if ( ! class_exists( 'WC_Klarna_Banners_KP' ) ) {
 			</div>
 
 			<?php
+		}
+
+		/**
+		 * Hide Klarna banner in admin pages for.
+		 */
+		public function hide_klarna_kp_banner() {
+			set_transient( 'klarna_kp_hide_banner', '1', 6 * DAY_IN_SECONDS );
+			wp_send_json_success( 'Hide Klarna Payment banner.' );
+			wp_die();
 		}
 
 		/**

--- a/klarna-payments-for-woocommerce.php
+++ b/klarna-payments-for-woocommerce.php
@@ -5,12 +5,12 @@
  * Description: Provides Klarna Payments as payment method to WooCommerce.
  * Author: krokedil, klarna, automattic
  * Author URI: https://krokedil.se/
- * Version: 1.5.2
+ * Version: 1.5.3
  * Text Domain: klarna-payments-for-woocommerce
  * Domain Path: /languages
  * 
  * WC requires at least: 3.0
- * WC tested up to: 3.4.3
+ * WC tested up to: 3.4.4
  * 
  * Copyright (c) 2017-2018 Krokedil
  *
@@ -35,7 +35,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Required minimums and constants
  */
-define( 'WC_KLARNA_PAYMENTS_VERSION', '1.5.2' );
+define( 'WC_KLARNA_PAYMENTS_VERSION', '1.5.3' );
 define( 'WC_KLARNA_PAYMENTS_MIN_PHP_VER', '5.4.0' );
 define( 'WC_KLARNA_PAYMENTS_MIN_WC_VER', '3.0.0' );
 define( 'WC_KLARNA_PAYMENTS_MAIN_FILE', __FILE__ );

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: klarna, krokedil, automattic
 Tags: woocommerce, klarna, ecommerce, e-commerce
 Donate link: https://klarna.com
 Requires at least: 4.0
-Tested up to: 4.9.7
+Tested up to: 4.9.8
 Requires PHP: 5.6
 Stable tag: trunk
 License: GPLv3 or later
@@ -53,6 +53,13 @@ For help setting up and configuring Klarna Payments for WooCommerce please refer
 * A SSL Certificate is required.
 
 == Changelog ==
+= 2018.08.17  	- version 1.5.3 =
+* Tweak			- Added filter kp_wc_api_request_args to be able to override order data sent to Klarna.
+* Tweak			- Added filter wc_klarna_payments_available_payment_categories to be able to override wich payment methods that should be available.
+* Tweak			- Logging improvements in klarna_payments_session_ajax_update function if request fails.
+* Tweak			- Added button for hiding Klarna banner in WP admin. Stays hidden for 6 days and then reappears again (if plugin still is in test mode).
+* Fix			- KP payment method not available on Order pay page (to avoid compatibility issues with Realex payment plugin).
+
 = 2018.07.23  	- version 1.5.2 =
 * Tweak			- Add max width to payment method icons.
 * Enhancement	- Added Klarna LEAP functionality (URL's for new customer signup & onboarding).

--- a/templates/klarna-payments-categories.php
+++ b/templates/klarna-payments-categories.php
@@ -4,7 +4,7 @@ if ( is_array( WC()->session->get( 'klarna_payments_categories' ) ) ) {
 	$available_gateways = WC()->payment_gateways()->get_available_payment_gateways();
 	$kp                 = $available_gateways['klarna_payments'];
 
-	foreach ( WC()->session->get( 'klarna_payments_categories' ) as $payment_category ) {
+	foreach ( apply_filters( 'wc_klarna_payments_available_payment_categories', WC()->session->get( 'klarna_payments_categories' ) ) as $payment_category ) {
 		$payment_category_id   = 'klarna_payments_' . $payment_category->identifier;
 		$payment_category_name = $payment_category->name;
 		$payment_category_icon = $payment_category->asset_urls->standard;


### PR DESCRIPTION
* Tweak - Added filter kp_wc_api_request_args to be able to override order data sent to Klarna.
* Tweak - Added filter wc_klarna_payments_available_payment_categories to be able to override wich payment methods that should be available.
* Tweak - Logging improvements in klarna_payments_session_ajax_update function if request fails.
* Tweak - Added button for hiding Klarna banner in WP admin. Stays hidden for 6 days and then reappears again (if plugin still is in test mode).
* Fix	- KP payment method not available on Order pay page (to avoid compatibility issues with Realex payment plugin).