### PR TITLE
1.6.3

### DIFF
--- a/assets/js/klarna-payments.js
+++ b/assets/js/klarna-payments.js
@@ -384,7 +384,7 @@ jQuery( function($) {
 					phone : $(klarna_payments_params.default_checkout_fields.billing_phone).val(),
 					country : $(klarna_payments_params.default_checkout_fields.billing_country).val(),
 					region : $(klarna_payments_params.default_checkout_fields.billing_region).val(),
-					postal_code : $(klarna_payments_params.default_checkout_fields.billing_postal_code).val(),
+					postal_code : ( klarna_payments_params.remove_postcode_spaces === 'yes' ) ? $(klarna_payments_params.default_checkout_fields.billing_postal_code).val().replace(/\s/g, '') : $(klarna_payments_params.default_checkout_fields.billing_postal_code).val(),
 					city : $(klarna_payments_params.default_checkout_fields.billing_city).val(),
 					street_address : $(klarna_payments_params.default_checkout_fields.billing_street_address).val(),
 					street_address2 : $(klarna_payments_params.default_checkout_fields.billing_street_address2).val(),
@@ -400,7 +400,7 @@ jQuery( function($) {
 				address.shipping_address.family_name = $(klarna_payments_params.default_checkout_fields.shipping_family_name).val();
 				address.shipping_address.country = $(klarna_payments_params.default_checkout_fields.shipping_country).val();
 				address.shipping_address.region = $(klarna_payments_params.default_checkout_fields.shipping_region).val();
-				address.shipping_address.postal_code = $(klarna_payments_params.default_checkout_fields.shipping_postal_code).val();
+				address.shipping_address.postal_code = ( klarna_payments_params.remove_postcode_spaces === 'yes' ) ? $(klarna_payments_params.default_checkout_fields.shipping_postal_code).val().replace(/\s/g, '') : $(klarna_payments_params.default_checkout_fields.shipping_postal_code).val();
 				address.shipping_address.city = $(klarna_payments_params.default_checkout_fields.shipping_city).val();
 				address.shipping_address.street_address = $(klarna_payments_params.default_checkout_fields.shipping_street_address).val();
 				address.shipping_address.street_address2 = $(klarna_payments_params.default_checkout_fields.shipping_street_address2).val();

--- a/assets/js/klarna-payments.js
+++ b/assets/js/klarna-payments.js
@@ -369,7 +369,7 @@ jQuery( function($) {
 			function handleVisibilityChange() {
 				if (! document[hidden]) {
 					if (klarna_payments.isKlarnaPaymentsSelected()) {
-						$('body').trigger('update_checkout');
+						//$('body').trigger('update_checkout');
 					}
 				}
 			}

--- a/includes/class-wc-gateway-klarna-payments.php
+++ b/includes/class-wc-gateway-klarna-payments.php
@@ -959,20 +959,22 @@ class WC_Gateway_Klarna_Payments extends WC_Payment_Gateway {
 		$order_lines           = $order_lines_processor->order_lines();
 		$posted_data           = $_POST; // Input var okay.
 		$billing_address       = array(
-			'given_name'      => stripslashes( $posted_data['billing_first_name'] ),
-			'family_name'     => stripslashes( $posted_data['billing_last_name'] ),
-			'email'           => stripslashes( $posted_data['billing_email'] ),
-			'phone'           => stripslashes( $posted_data['billing_phone'] ),
-			'street_address'  => stripslashes( $posted_data['billing_address_1'] ),
-			'street_address2' => stripslashes( $posted_data['billing_address_2'] ),
-			'postal_code'     => stripslashes( $posted_data['billing_postcode'] ),
-			'city'            => stripslashes( $posted_data['billing_city'] ),
-			'region'          => stripslashes( $posted_data['billing_state'] ),
-			'country'         => stripslashes( $posted_data['billing_country'] ),
+			'given_name'        => stripslashes( $posted_data['billing_first_name'] ),
+			'family_name'       => stripslashes( $posted_data['billing_last_name'] ),
+			'email'             => stripslashes( $posted_data['billing_email'] ),
+			'phone'             => stripslashes( $posted_data['billing_phone'] ),
+			'street_address'    => stripslashes( $posted_data['billing_address_1'] ),
+			'street_address2'   => stripslashes( $posted_data['billing_address_2'] ),
+			'postal_code'       => stripslashes( $posted_data['billing_postcode'] ),
+			'city'              => stripslashes( $posted_data['billing_city'] ),
+			'region'            => stripslashes( $posted_data['billing_state'] ),
+			'country'           => stripslashes( $posted_data['billing_country'] ),
+			'organization_name' => stripslashes( $posted_data['billing_company'] ),
 		);
+		/*
 		if ( isset( $posted_data['billing_company'] ) && '' !== $posted_data['billing_company'] ) {
 			$billing_address['organization_name'] = stripslashes( $posted_data['billing_company'] );
-		}
+		}*/
 
 		if ( ! empty( $_POST['ship_to_different_address'] ) && ! wc_ship_to_billing_address_only() && 'b2c' === $this->get_option( 'customer_type' ) ) { // Input var okay.
 			$shipping_address = array(

--- a/includes/class-wc-gateway-klarna-payments.php
+++ b/includes/class-wc-gateway-klarna-payments.php
@@ -761,11 +761,13 @@ class WC_Gateway_Klarna_Payments extends WC_Payment_Gateway {
 		);
 
 		// Localize the script.
-		$klarna_payments_params                            = array();
-		$klarna_payments_params['testmode']                = $this->testmode;
-		$klarna_payments_params['default_checkout_fields'] = apply_filters( 'wc_klarna_payments_default_checkout_fields', $default_kp_checkout_fields );
-		$klarna_payments_params['customer_type']           = $this->get_option( 'customer_type' );
-		$klarna_payments_params['remove_postcode_spaces']  = ( apply_filters( 'wc_kp_remove_postcode_spaces', false ) ) ? 'yes' : 'no';
+		$klarna_payments_params                                    = array();
+		$klarna_payments_params['testmode']                        = $this->testmode;
+		$klarna_payments_params['default_checkout_fields']         = apply_filters( 'wc_klarna_payments_default_checkout_fields', $default_kp_checkout_fields );
+		$klarna_payments_params['customer_type']                   = $this->get_option( 'customer_type' );
+		$klarna_payments_params['remove_postcode_spaces']          = ( apply_filters( 'wc_kp_remove_postcode_spaces', false ) ) ? 'yes' : 'no';
+		$klarna_payments_params['failed_field_validation_text']    = __( ' is a required field.', 'woocommerce' );
+		$klarna_payments_params['failed_checkbox_validation_text'] = __( 'Make sure all required checkboxes are checked.', 'klarna-payments-for-woocommerce' );
 
 		wp_localize_script( 'klarna_payments', 'klarna_payments_params', $klarna_payments_params );
 		wp_enqueue_script( 'klarna_payments' );

--- a/includes/class-wc-gateway-klarna-payments.php
+++ b/includes/class-wc-gateway-klarna-payments.php
@@ -817,7 +817,7 @@ class WC_Gateway_Klarna_Payments extends WC_Payment_Gateway {
 	public function process_payment( $order_id ) {
 		$auth_token = sanitize_text_field( $_POST['klarna_payments_authorization_token'] ); // Input var okay.
 
-		$order = wc_get_order( $order_id );
+		$order    = wc_get_order( $order_id );
 		$response = $this->place_order( $order_id, $auth_token ); // Place order.
 
 		return $this->process_klarna_response( $response, $order );
@@ -1248,7 +1248,7 @@ class WC_Gateway_Klarna_Payments extends WC_Payment_Gateway {
 	 * @return array
 	 */
 	public function set_klarna_customer() {
-		$type = ( 'b2c' === $this->get_option( 'customer_type' ) ) ? 'person' : 'organization';
+		$type = ( 'b2c' === $this->get_option( 'customer_type', 'b2c' ) ) ? 'person' : 'organization';
 		return array(
 			'type' => $type,
 		);

--- a/includes/class-wc-gateway-klarna-payments.php
+++ b/includes/class-wc-gateway-klarna-payments.php
@@ -817,7 +817,7 @@ class WC_Gateway_Klarna_Payments extends WC_Payment_Gateway {
 	public function process_payment( $order_id ) {
 		$auth_token = sanitize_text_field( $_POST['klarna_payments_authorization_token'] ); // Input var okay.
 
-		$order    = wc_get_order( $order_id );
+		$order = wc_get_order( $order_id );
 		$response = $this->place_order( $order_id, $auth_token ); // Place order.
 
 		return $this->process_klarna_response( $response, $order );

--- a/includes/class-wc-gateway-klarna-payments.php
+++ b/includes/class-wc-gateway-klarna-payments.php
@@ -185,6 +185,13 @@ class WC_Gateway_Klarna_Payments extends WC_Payment_Gateway {
 	 */
 	public $float_what_is_klarna;
 
+
+	/**
+	 * Hide what is Klarna? link in checkout page.
+	 *
+	 * @var string
+	 */
+	public $hide_what_is_klarna;
 	/**
 	 * Constructor
 	 */
@@ -230,6 +237,7 @@ class WC_Gateway_Klarna_Payments extends WC_Payment_Gateway {
 		$this->radius_border            = $this->get_option( 'radius_border' );
 
 		// What is Klarna link.
+		$this->hide_what_is_klarna  = 'yes' === $this->get_option( 'hide_what_is_klarna' );
 		$this->float_what_is_klarna = 'yes' === $this->get_option( 'float_what_is_klarna' );
 		$env_string                 = 'US' === $this->klarna_country ? '-na' : '';
 		if ( $this->testmode ) {
@@ -306,32 +314,33 @@ class WC_Gateway_Klarna_Payments extends WC_Payment_Gateway {
 	 * @return string
 	 */
 	public function get_icon() {
-		// If default WooCommerce CSS is used, float "What is Klarna link like PayPal does it".
-		if ( $this->float_what_is_klarna ) {
-			$link_style = 'style="float: right; line-height: 52px; font-size: .83em;"';
-		} else {
-			$link_style = '';
-		}
-
-		$what_is_klarna_text = 'What is Klarna?';
-
-		if ( 'us' === strtolower( $this->klarna_country ) ) {
-			$link_url = 'https://www.klarna.com/us/business/what-is-klarna';
-		} elseif ( 'at' === strtolower( $this->klarna_country ) || 'de' === strtolower( $this->klarna_country ) ) {
-			$link_url = 'https://www.klarna.com';
-		} else {
-			$link_url = 'https://www.klarna.com/uk/what-we-do';
-		}
-
-		// Change text for Germany
-		$locale = get_locale();
-		if ( stripos( $locale, 'de' ) !== false ) {
-			$what_is_klarna_text = 'Was ist Klarna?';
-		}
 		$icon_width = '39';
 		$icon_html  = '<img src="' . $this->icon . '" alt="Klarna" style="max-width:' . $icon_width . 'px"/>';
-		$icon_html .= '<a ' . $link_style . ' href="' . $link_url . '" onclick="window.open(\'' . $link_url . '\',\'WIKlarna\',\'toolbar=no, location=no, directories=no, status=no, menubar=no, scrollbars=yes, resizable=yes, width=1060, height=700\'); return false;">' . $what_is_klarna_text . '</a>';
+		if ( ! $this->hide_what_is_klarna ) {
+			// If default WooCommerce CSS is used, float "What is Klarna link like PayPal does it".
+			if ( $this->float_what_is_klarna ) {
+				$link_style = 'style="float: right; line-height: 52px; font-size: .83em;"';
+			} else {
+				$link_style = '';
+			}
 
+			$what_is_klarna_text = 'What is Klarna?';
+
+			if ( 'us' === strtolower( $this->klarna_country ) ) {
+				$link_url = 'https://www.klarna.com/us/business/what-is-klarna';
+			} elseif ( 'at' === strtolower( $this->klarna_country ) || 'de' === strtolower( $this->klarna_country ) ) {
+				$link_url = 'https://www.klarna.com';
+			} else {
+				$link_url = 'https://www.klarna.com/uk/what-we-do';
+			}
+
+			// Change text for Germany
+			$locale = get_locale();
+			if ( stripos( $locale, 'de' ) !== false ) {
+				$what_is_klarna_text = 'Was ist Klarna?';
+			}
+			$icon_html .= '<a ' . $link_style . ' href="' . $link_url . '" onclick="window.open(\'' . $link_url . '\',\'WIKlarna\',\'toolbar=no, location=no, directories=no, status=no, menubar=no, scrollbars=yes, resizable=yes, width=1060, height=700\'); return false;">' . $what_is_klarna_text . '</a>';
+		}
 		return apply_filters( 'woocommerce_gateway_icon', $icon_html, $this->id );
 	}
 

--- a/includes/class-wc-gateway-klarna-payments.php
+++ b/includes/class-wc-gateway-klarna-payments.php
@@ -765,6 +765,7 @@ class WC_Gateway_Klarna_Payments extends WC_Payment_Gateway {
 		$klarna_payments_params['testmode']                = $this->testmode;
 		$klarna_payments_params['default_checkout_fields'] = apply_filters( 'wc_klarna_payments_default_checkout_fields', $default_kp_checkout_fields );
 		$klarna_payments_params['customer_type']           = $this->get_option( 'customer_type' );
+		$klarna_payments_params['remove_postcode_spaces']  = ( apply_filters( 'wc_kp_remove_postcode_spaces', false ) ) ? 'yes' : 'no';
 
 		wp_localize_script( 'klarna_payments', 'klarna_payments_params', $klarna_payments_params );
 		wp_enqueue_script( 'klarna_payments' );
@@ -972,7 +973,7 @@ class WC_Gateway_Klarna_Payments extends WC_Payment_Gateway {
 			'phone'             => stripslashes( $posted_data['billing_phone'] ),
 			'street_address'    => stripslashes( $posted_data['billing_address_1'] ),
 			'street_address2'   => stripslashes( $posted_data['billing_address_2'] ),
-			'postal_code'       => stripslashes( $posted_data['billing_postcode'] ),
+			'postal_code'       => stripslashes( ( apply_filters( 'wc_kp_remove_postcode_spaces', false ) ) ? str_replace( ' ', '', $posted_data['billing_postcode'] ) : $posted_data['billing_postcode'] ),
 			'city'              => stripslashes( $posted_data['billing_city'] ),
 			'region'            => stripslashes( $posted_data['billing_state'] ),
 			'country'           => stripslashes( $posted_data['billing_country'] ),
@@ -991,7 +992,7 @@ class WC_Gateway_Klarna_Payments extends WC_Payment_Gateway {
 				'phone'           => stripslashes( $posted_data['shipping_email'] ),
 				'street_address'  => stripslashes( $posted_data['shipping_address_1'] ),
 				'street_address2' => stripslashes( $posted_data['shipping_address_2'] ),
-				'postal_code'     => stripslashes( $posted_data['shipping_postcode'] ),
+				'postal_code'     => stripslashes( ( apply_filters( 'wc_kp_remove_postcode_spaces', false ) ) ? str_replace( ' ', '', $posted_data['shipping_postcode'] ) : $posted_data['shipping_postcode'] ),
 				'city'            => stripslashes( $posted_data['shipping_city'] ),
 				'region'          => stripslashes( $posted_data['shipping_state'] ),
 				'country'         => stripslashes( $posted_data['shipping_country'] ),
@@ -1029,7 +1030,6 @@ class WC_Gateway_Klarna_Payments extends WC_Payment_Gateway {
 			),
 		);
 		$response     = wp_safe_remote_post( $request_url, $request_args );
-
 		return $response;
 	}
 

--- a/includes/class-wc-gateway-klarna-payments.php
+++ b/includes/class-wc-gateway-klarna-payments.php
@@ -829,8 +829,7 @@ class WC_Gateway_Klarna_Payments extends WC_Payment_Gateway {
 		$order         = wc_get_order( $order_id );
 		$response      = $this->place_order( $order_id, $auth_token ); // Place order.
 		$response_body = json_decode( wp_remote_retrieve_body( $response ), true );
-		$this->set_payment_method_title( $order, $response_body );
-
+		// $this->set_payment_method_title( $order, $response_body );
 		return $this->process_klarna_response( $response, $order );
 	}
 
@@ -1271,6 +1270,7 @@ class WC_Gateway_Klarna_Payments extends WC_Payment_Gateway {
 	 * @param array $order WooCommerce order.
 	 * @param array $klarna_place_order_response The Klarna place order response.
 	 * @return void
+	 * @todo Change it so that it dynamically gets information from Klarna.
 	 */
 	public function set_payment_method_title( $order, $klarna_place_order_response ) {
 		$title         = $order->get_payment_method_title();

--- a/includes/class-wc-gateway-klarna-payments.php
+++ b/includes/class-wc-gateway-klarna-payments.php
@@ -205,7 +205,7 @@ class WC_Gateway_Klarna_Payments extends WC_Payment_Gateway {
 		$this->init_settings();
 
 		// Get setting values.
-		// $this->title    = $this->get_option( 'title' );
+		$this->title    = $this->get_option( 'title' );
 		$this->enabled  = $this->get_option( 'enabled' );
 		$this->testmode = 'yes' === $this->get_option( 'testmode' );
 		$this->logging  = 'yes' === $this->get_option( 'logging' );

--- a/includes/class-wc-klarna-banners.php
+++ b/includes/class-wc-klarna-banners.php
@@ -86,7 +86,7 @@ if ( ! class_exists( 'WC_Klarna_Banners_KP' ) ) {
 						<p>Pay now, Pay later and Slice it. Klarna is entering a new world of smoooth. We would love for you to join us on the ride and to do so, you will need to upgrade your Klarna products to a new integration. You will then always get the latest features that Klarna develops and you’ll keep your current agreement along with your price settings.</p>
 						<a class="kb-button"
 						   href="https://hello.klarna.com/product-upgrade?utm_source=woo-backend&utm_medium=referral&utm_campaign=woo&utm_content=banner"
-						   target="_blank">Upgrade you contract with Klarna</a>
+						   target="_blank">Upgrade your contract with Klarna</a>
 					</div>
 					<img id="kb-image"
 						 src="<?php echo esc_url( WC_KLARNA_PAYMENTS_PLUGIN_URL ); ?>/assets/img/klarna_logo_white.png"

--- a/includes/class-wc-klarna-banners.php
+++ b/includes/class-wc-klarna-banners.php
@@ -56,7 +56,7 @@ if ( ! class_exists( 'WC_Klarna_Banners_KP' ) ) {
 			$plugin         = 'klarna-payments-for-woocommerce';
 			$plugin_version = WC_KLARNA_PAYMENTS_VERSION;
 			$wc_version     = defined( 'WC_VERSION' ) && WC_VERSION ? WC_VERSION : null;
-			$url_queries    = '?country='. $country .'&products=kp&plugin=' . $plugin . '&pluginVersion=' . $plugin_version . '&platform=woocommerce&platformVersion=' . $wc_version;
+			$url_queries    = '?country=' . $country . '&products=kp&plugin=' . $plugin . '&pluginVersion=' . $plugin_version . '&platform=woocommerce&platformVersion=' . $wc_version;
 
 			if ( 'US' !== $country ) {
 				$url_base = 'https://eu.portal.klarna.com/signup/';
@@ -70,7 +70,7 @@ if ( ! class_exists( 'WC_Klarna_Banners_KP' ) ) {
 				$show_banner = true;
 			}
 
-			if ( $show_banner  && false === get_transient( 'klarna_kp_hide_banner' ) ) {
+			if ( $show_banner && false === get_transient( 'klarna_kp_hide_banner' ) ) {
 				?>
 				<div id="kb-spacer"></div>
 				<div id="klarna-kp-banner">
@@ -103,7 +103,7 @@ if ( ! class_exists( 'WC_Klarna_Banners_KP' ) ) {
 								ajaxurl,
 								{
 									action		: 'hide_klarna_kp_banner',
-									_wpnonce	: '<?php echo wp_create_nonce('hide-klarna-kp-banner'); ?>',
+									_wpnonce	: '<?php echo wp_create_nonce( 'hide-klarna-kp-banner' ); ?>',
 								},
 								function(response){
 									console.log('Success hide kp banner');
@@ -169,13 +169,13 @@ if ( ! class_exists( 'WC_Klarna_Banners_KP' ) ) {
 			$plugin         = 'klarna-payments-for-woocommerce';
 			$plugin_version = WC_KLARNA_PAYMENTS_VERSION;
 			$wc_version     = defined( 'WC_VERSION' ) && WC_VERSION ? WC_VERSION : null;
-			$url_queries    = '?country='. $country .'&products=kp&plugin=' . $plugin . '&pluginVersion=' . $plugin_version . '&platform=woocommerce&platformVersion=' . $wc_version;
+			$url_queries    = '?country=' . $country . '&products=kp&plugin=' . $plugin . '&pluginVersion=' . $plugin_version . '&platform=woocommerce&platformVersion=' . $wc_version;
 
 			if ( 'US' !== $country ) {
 				$url_base = 'https://eu.portal.klarna.com/signup/';
-				$url = $url_base . $url_queries;
+				$url      = $url_base . $url_queries;
 			} else {
-				//$url_base = 'https://us.portal.klarna.com/signup/';
+				// $url_base = 'https://us.portal.klarna.com/signup/';
 				$url = 'https://www.klarna.com/international/business/woocommerce/?utm_source=woo-backend&utm_medium=referral&utm_campaign=woo&utm_content=kp';
 			}
 			return $url;

--- a/includes/klarna-payments-admin-form-fields.php
+++ b/includes/klarna-payments-admin-form-fields.php
@@ -44,8 +44,15 @@ class Klarna_Payments_Form_Fields {
 					'default'     => 'no',
 					'desc_tip'    => true,
 				),
+				'hide_what_is_klarna'      => array(
+					'title'    => __( 'Hide What is Klarna? link', 'klarna-payments-for-woocommerce' ),
+					'type'     => 'checkbox',
+					'label'    => __( 'If checked, What is Klarna? will not be shown.', 'klarna-payments-for-woocommerce' ),
+					'default'  => 'no',
+					'desc_tip' => true,
+				),
 				'float_what_is_klarna'     => array(
-					'title'    => __( 'What is Klarna? link', 'klarna-payments-for-woocommerce' ),
+					'title'    => __( 'Float What is Klarna? link', 'klarna-payments-for-woocommerce' ),
 					'type'     => 'checkbox',
 					'label'    => __( 'If checked, What is Klarna? will be floated right.', 'klarna-payments-for-woocommerce' ),
 					'default'  => 'yes',

--- a/klarna-payments-for-woocommerce.php
+++ b/klarna-payments-for-woocommerce.php
@@ -5,12 +5,12 @@
  * Description: Provides Klarna Payments as payment method to WooCommerce.
  * Author: krokedil, klarna, automattic
  * Author URI: https://krokedil.se/
- * Version: 1.6.2
+ * Version: 1.6.3
  * Text Domain: klarna-payments-for-woocommerce
  * Domain Path: /languages
  *
  * WC requires at least: 3.3.0
- * WC tested up to: 3.4.7
+ * WC tested up to: 3.5.1
  *
  * Copyright (c) 2017-2018 Krokedil
  *
@@ -35,8 +35,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Required minimums and constants
  */
-define( 'WC_KLARNA_PAYMENTS_VERSION', '1.6.2' );
-define( 'WC_KLARNA_PAYMENTS_MIN_PHP_VER', '5.4.0' );
+define( 'WC_KLARNA_PAYMENTS_VERSION', '1.6.3' );
+define( 'WC_KLARNA_PAYMENTS_MIN_PHP_VER', '5.6.0' );
 define( 'WC_KLARNA_PAYMENTS_MIN_WC_VER', '3.3.0' );
 define( 'WC_KLARNA_PAYMENTS_MAIN_FILE', __FILE__ );
 define( 'WC_KLARNA_PAYMENTS_PLUGIN_PATH', untrailingslashit( plugin_dir_path( __FILE__ ) ) );

--- a/klarna-payments-for-woocommerce.php
+++ b/klarna-payments-for-woocommerce.php
@@ -8,10 +8,10 @@
  * Version: 1.6.0
  * Text Domain: klarna-payments-for-woocommerce
  * Domain Path: /languages
- * 
+ *
  * WC requires at least: 3.3.0
  * WC tested up to: 3.4.5
- * 
+ *
  * Copyright (c) 2017-2018 Krokedil
  *
  * This program is free software: you can redistribute it and/or modify
@@ -35,7 +35,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Required minimums and constants
  */
-define( 'WC_KLARNA_PAYMENTS_VERSION', '1.6.0' );
+define( 'WC_KLARNA_PAYMENTS_VERSION', '1.6.1' );
 define( 'WC_KLARNA_PAYMENTS_MIN_PHP_VER', '5.4.0' );
 define( 'WC_KLARNA_PAYMENTS_MIN_WC_VER', '3.3.0' );
 define( 'WC_KLARNA_PAYMENTS_MAIN_FILE', __FILE__ );
@@ -110,10 +110,12 @@ if ( ! class_exists( 'WC_Klarna_Payments' ) ) {
 			add_action( 'plugins_loaded', array( $this, 'init' ) );
 			add_action( 'admin_notices', array( $this, 'order_management_check' ) );
 			add_filter( 'woocommerce_checkout_posted_data', array( $this, 'filter_payment_method_id' ) );
-			add_filter( 'woocommerce_process_checkout_field_billing_phone', array(
-				$this,
-				'maybe_filter_billing_phone',
-			) );
+			add_filter(
+				'woocommerce_process_checkout_field_billing_phone', array(
+					$this,
+					'maybe_filter_billing_phone',
+				)
+			);
 		}
 
 		/**

--- a/klarna-payments-for-woocommerce.php
+++ b/klarna-payments-for-woocommerce.php
@@ -5,12 +5,12 @@
  * Description: Provides Klarna Payments as payment method to WooCommerce.
  * Author: krokedil, klarna, automattic
  * Author URI: https://krokedil.se/
- * Version: 1.6.0
+ * Version: 1.6.2
  * Text Domain: klarna-payments-for-woocommerce
  * Domain Path: /languages
  *
  * WC requires at least: 3.3.0
- * WC tested up to: 3.4.5
+ * WC tested up to: 3.4.7
  *
  * Copyright (c) 2017-2018 Krokedil
  *
@@ -35,7 +35,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Required minimums and constants
  */
-define( 'WC_KLARNA_PAYMENTS_VERSION', '1.6.1' );
+define( 'WC_KLARNA_PAYMENTS_VERSION', '1.6.2' );
 define( 'WC_KLARNA_PAYMENTS_MIN_PHP_VER', '5.4.0' );
 define( 'WC_KLARNA_PAYMENTS_MIN_WC_VER', '3.3.0' );
 define( 'WC_KLARNA_PAYMENTS_MAIN_FILE', __FILE__ );

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: klarna, krokedil, automattic
 Tags: woocommerce, klarna, ecommerce, e-commerce
 Donate link: https://klarna.com
 Requires at least: 4.0
-Tested up to: 4.9.8
+Tested up to: 5.0
 Requires PHP: 5.6
 Stable tag: trunk
 License: GPLv3 or later
@@ -48,11 +48,22 @@ Klarna Payments works for merchants in Sweden, Denmark, Finland, Norway, Germany
 For help setting up and configuring Klarna Payments for WooCommerce please refer to our [documentation](https://docs.woocommerce.com/document/klarna-payments/).
 
 = Are there any specific requirements? =
-* WooCommerce 3.0 or newer is required.
+* WooCommerce 3.3.0 or newer is required.
 * PHP 5.6 or higher is required.
 * A SSL Certificate is required.
 
 == Changelog ==
+= 2018.11.27  	- version 1.6.3 =
+* Feature		- Added setting to hide "What is Klarna?" link.
+* Tweak			- Added filter wc_kp_remove_postcode_spaces to enable removing whitespace from postcode posted to Klarna.
+* Tweak			- Removed update order on visibility change.
+* Tweak			- Default customer type to b2c if setting is not saved in db.
+* Tweak			- Plugin WordPress 5.0 compatible.
+* Fix			- Added support for additional required fields (other than Woo standard) on checkout. Prevents Klarna iframe from showing before all fields are entered.
+* Fix			- Narrowed search for checkout field changes. Prevents some themes from entering infinite loop that loads the Klarna iframe.
+* Fix			- Made payment method title editable again.
+* Fix			- Add round to fees sent to Klarna.
+
 = 2018.10.19  	- version 1.6.2 =
 * Enhancement 	- Changed so all payment methods have the same ID in frontend as in the factory gateway. Adds support for payment gateway based fees and similar plugins.
 * Fix 			- Fixed no tax being applied to negative fee.

--- a/readme.txt
+++ b/readme.txt
@@ -53,6 +53,10 @@ For help setting up and configuring Klarna Payments for WooCommerce please refer
 * A SSL Certificate is required.
 
 == Changelog ==
+= 2018.10.19  	- version 1.6.2 =
+* Enhancement 	- Changed so all payment methods have the same ID in frontend as in the factory gateway. Adds support for payment gateway based fees and similar plugins.
+* Fix 			- Fixed no tax being applied to negative fee.
+
 = 2018.09.25  	- version 1.6.1 =
 * Fix		    - Fixed 409 error caused by missing Organization name field.
 * Fix		    - Better support for Switzerland.

--- a/readme.txt
+++ b/readme.txt
@@ -53,6 +53,10 @@ For help setting up and configuring Klarna Payments for WooCommerce please refer
 * A SSL Certificate is required.
 
 == Changelog ==
+= 2018.09.25  	- version 1.6.1 =
+* Fix		    - Fixed 409 error caused by missing Organization name field.
+* Fix		    - Better support for Switzerland.
+
 = 2018.09.20  	- version 1.6.0 =
 * Feature		- Added support for B2B purchases.
 * Feature		- Added support Switzerland.

--- a/templates/klarna-payments-categories.php
+++ b/templates/klarna-payments-categories.php
@@ -8,12 +8,11 @@ if ( is_array( WC()->session->get( 'klarna_payments_categories' ) ) ) {
 		$payment_category_id   = 'klarna_payments_' . $payment_category->identifier;
 		$payment_category_name = $payment_category->name;
 		$payment_category_icon = $payment_category->asset_urls->standard;
-
-		$kp        = $available_gateways['klarna_payments'];
-		$kp->id    = $payment_category_id;
-		$kp->title = $payment_category_name;
-		$kp->icon  = $payment_category_icon;
-		$headers   = get_headers( $kp->icon );
+		$kp                    = $available_gateways['klarna_payments'];
+		$kp->id                = $payment_category_id;
+		$kp->title             = $payment_category_name;
+		$kp->icon              = $payment_category_icon;
+		$headers               = get_headers( $kp->icon );
 		if ( 'HTTP/1.1 404 Not Found' === $headers[0] ) {
 			switch ( $kp->id ) {
 				case 'klarna_payments_pay_later':


### PR DESCRIPTION
* Feature - Added setting to hide "What is Klarna?" link.
* Tweak - Added filter wc_kp_remove_postcode_spaces to enable removing whitespace from postcode posted to Klarna.
* Tweak - Removed update order on visibility change.
* Tweak - Default customer type to b2c if setting is not saved in db.
* Tweak - Plugin WordPress 5.0 compatible.
* Fix - Added support for additional required fields (other than Woo standard) on checkout. Prevents Klarna iframe from showing before all fields are entered.
* Fix - Narrowed search for checkout field changes. Prevents some themes from entering infinite loop that loads the Klarna iframe.
* Fix - Made payment method title editable again.
* Fix - Add round to fees sent to Klarna.