### PR TITLE
Only parse the hash values if the correct hash is detected.

### DIFF
--- a/assets/js/klarna-payments.js
+++ b/assets/js/klarna-payments.js
@@ -302,9 +302,10 @@ jQuery( function($) {
 		handleHashChange: function( event ) {
 			var currentHash = location.hash;
 			var splittedHash = currentHash.split("=");
-			var json =  JSON.parse( atob( splittedHash[1] ) );
+
             if( splittedHash[0] === "#kp" ){
-                var response = JSON.parse( atob( splittedHash[1] ) );
+                var json = JSON.parse( atob( splittedHash[1] ) );
+
 				klarna_payments.authorize().done( function( response ) {
 					if ('authorization_token' in response) {
 						$.ajax(


### PR DESCRIPTION
For checkout pages that have other hashes, a JS error is thrown by the `handleHashChange()`. This change makes sure that the hash being parsed is actually from Klarna.