### PR TITLE
1.8.4

### DIFF
--- a/assets/js/klarna-payments.js
+++ b/assets/js/klarna-payments.js
@@ -157,7 +157,7 @@ jQuery( function($) {
 						};
 
 						if ( 'US' === $('#billing_country').val() ) {
-							var address = klarna_payments.get_address();
+							var address = klarna_payments.get_address_from_checkout_form();
 
 							Klarna.Payments.load(
 								options,
@@ -275,6 +275,40 @@ jQuery( function($) {
 				address.shipping_address.city = klarna_payments.addresses.shipping.city;
 				address.shipping_address.street_address = klarna_payments.addresses.shipping.street_address;
 				address.shipping_address.street_address2 = klarna_payments.addresses.shipping.street_address2;
+			}
+
+			return address;
+		},
+
+		get_address_from_checkout_form: function() {
+			var address = {
+				billing_address: {
+					given_name : klarna_payments.checkout_values.billing_first_name,
+					family_name : klarna_payments.checkout_values.billing_last_name,
+					email : klarna_payments.checkout_values.billing_email,
+					phone : klarna_payments.checkout_values.billing_phone,
+					country : klarna_payments.checkout_values.billing_country,
+					region : klarna_payments.checkout_values.billing_state,
+					postal_code : klarna_payments.checkout_values.billing_postcode,
+					city : klarna_payments.checkout_values.billing_city,
+					street_address : klarna_payments.checkout_values.billing_address_1,
+					street_address2 : klarna_payments.checkout_values.billing_address_2,
+					organization_name : ( 'b2b' === klarna_payments_params.customer_type ) ? klarna_payments.checkout_values.billing_company : '',
+				},
+				shipping_address: {}
+			};
+
+			address.shipping_address = $.extend({}, address.billing_address);
+
+			if ( $( '#ship-to-different-address' ).find( 'input' ).is( ':checked' ) ) {
+				address.shipping_address.given_name = klarna_payments.checkout_values.shipping_first_name;
+				address.shipping_address.family_name = klarna_payments.checkout_values.shipping_last_name;
+				address.shipping_address.country = klarna_payments.checkout_values.shipping_country;
+				address.shipping_address.region = klarna_payments.checkout_values.shipping_state;
+				address.shipping_address.postal_code = klarna_payments.checkout_values.shipping_postcode;
+				address.shipping_address.city = klarna_payments.checkout_values.shipping_city;
+				address.shipping_address.street_address = klarna_payments.checkout_values.shipping_address_1;
+				address.shipping_address.street_address2 = klarna_payments.checkout_values.shipping_address_2;
 			}
 
 			return address;

--- a/klarna-payments-for-woocommerce.php
+++ b/klarna-payments-for-woocommerce.php
@@ -5,12 +5,12 @@
  * Description: Provides Klarna Payments as payment method to WooCommerce.
  * Author: krokedil, klarna, automattic
  * Author URI: https://krokedil.com/
- * Version: 1.8.3
+ * Version: 1.8.4
  * Text Domain: klarna-payments-for-woocommerce
  * Domain Path: /languages
  *
  * WC requires at least: 3.3.0
- * WC tested up to: 3.6.4
+ * WC tested up to: 3.7.0
  *
  * Copyright (c) 2017-2019 Krokedil
  *
@@ -35,7 +35,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Required minimums and constants
  */
-define( 'WC_KLARNA_PAYMENTS_VERSION', '1.8.3' );
+define( 'WC_KLARNA_PAYMENTS_VERSION', '1.8.4' );
 define( 'WC_KLARNA_PAYMENTS_MIN_PHP_VER', '5.6.0' );
 define( 'WC_KLARNA_PAYMENTS_MIN_WC_VER', '3.3.0' );
 define( 'WC_KLARNA_PAYMENTS_MAIN_FILE', __FILE__ );

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: klarna, krokedil, automattic
 Tags: woocommerce, klarna, ecommerce, e-commerce
 Donate link: https://klarna.com
 Requires at least: 4.0
-Tested up to: 5.2.4
+Tested up to: 5.2.2
 Requires PHP: 5.6
 Stable tag: trunk
 License: GPLv3 or later
@@ -53,6 +53,9 @@ For help setting up and configuring Klarna Payments for WooCommerce please refer
 * A SSL Certificate is required.
 
 == Changelog ==
+= 2019.08.13  	- version 1.8.4 =
+* Fix           - Send address data to Klarna from checkout form on load call for US stores. Plugin rewrite caused payment method iframe not to be displayed for US stores.
+
 = 2019.08.10  	- version 1.8.3 =
 * Enhancement	- We now use order data for authorization calls. This prevents issues with difference in formating of adress details between create order and authorization.
 * Enhancement	- Changed the text added to the order note to "Payment rejected by Klarna" on a failed authorization calls.


### PR DESCRIPTION
* Fix - Send address data to Klarna from checkout form on load call for US stores. Plugin rewrite caused payment method iframe not to be displayed for US stores.