### PR TITLE
1.9.0

### DIFF
--- a/assets/js/klarna-payments.js
+++ b/assets/js/klarna-payments.js
@@ -354,12 +354,23 @@ jQuery( function($) {
 									order_id: json.order_id,
 									auth_token: klarna_payments.authorization_response.authorization_token,
 								},
+								success: function (response) {
+									// Log the success.
+									console.log('kp_place_order sucess');
+									console.log(response);
+								},
+								error: function (response) {
+									// Log the error.
+									console.log('kp_place_order error');
+									console.log(response);
+								},
 								complete: function (response) {
 									window.location.href = response.responseJSON.data;
 								}
 							}
 						);
 					} else {
+						console.log('No authorization_token in response');
 						$.ajax(
 							klarna_payments_params.ajaxurl,
 							{

--- a/includes/class-wc-klarna-payments-order-lines.php
+++ b/includes/class-wc-klarna-payments-order-lines.php
@@ -243,8 +243,8 @@ class WC_Klarna_Payments_Order_Lines {
 				$coupon_amount     = 0;
 				$coupon_tax_amount = '';
 
-				// Smart coupons are processed as real line items, cart and product discounts sent for reference only.
-				if ( 'smart_coupon' === $coupon->get_discount_type() ) {
+				// Smart coupons and store credit are processed as real line items, cart and product discounts sent for reference only.
+				if ( 'smart_coupon' === $coupon->get_discount_type() || 'store_credit' === $coupon->get_discount_type() ) {
 					$coupon_amount     = - round( WC()->cart->get_coupon_discount_amount( $coupon_key ) * 100 );
 					$coupon_tax_amount = - round( WC()->cart->get_coupon_discount_tax_amount( $coupon_key ) * 100 );
 					$coupon_reference  = 'Discount';
@@ -265,8 +265,8 @@ class WC_Klarna_Payments_Order_Lines {
 					}
 				}
 
-				// Add separate discount line item, but only if it's a smart coupon or country is US.
-				if ( 'smart_coupon' === $coupon->get_discount_type() || 'US' === $this->shop_country ) {
+				// Add separate discount line item, but only if it's a smart coupon, store credit or country is US.
+				if ( 'smart_coupon' === $coupon->get_discount_type() || 'store_credit' === $coupon->get_discount_type() || 'US' === $this->shop_country ) {
 					$discount = array(
 						'type'                  => 'discount',
 						'reference'             => $coupon_reference,

--- a/includes/class-wc-klarna-payments-order-lines.php
+++ b/includes/class-wc-klarna-payments-order-lines.php
@@ -269,7 +269,7 @@ class WC_Klarna_Payments_Order_Lines {
 				if ( 'smart_coupon' === $coupon->get_discount_type() || 'store_credit' === $coupon->get_discount_type() || 'US' === $this->shop_country ) {
 					$discount = array(
 						'type'                  => 'discount',
-						'reference'             => $coupon_reference,
+						'reference'             => substr( strval( $coupon_reference ), 0, 64 ),
 						'name'                  => $coupon_key,
 						'quantity'              => 1,
 						'unit_price'            => $coupon_amount,
@@ -762,7 +762,7 @@ class WC_Klarna_Payments_Order_Lines {
 			$shipping_reference = __( 'Shipping', 'klarna-payments-for-woocommerce' );
 		}
 
-		return (string) $shipping_reference;
+		return substr( strval( $shipping_reference ), 0, 64 );
 	}
 
 	/**
@@ -898,13 +898,13 @@ class WC_Klarna_Payments_Order_Lines {
 	 * Get the order shipping reference
 	 *
 	 * @param object $order
-	 * @return void
+	 * @return string $order_shipping_reference Reference for selected shipping method
 	 */
 	private function get_order_shipping_reference( $order ) {
 		$order_shipping_items = $order->get_items( 'shipping' );
 		foreach ( $order_shipping_items as $order_shipping_item ) {
 			$order_shipping_reference = $order_shipping_item->get_method_id() . ':' . $order_shipping_item->get_instance_id();
 		}
-		return $order_shipping_reference;
+		return substr( strval( $order_shipping_reference ), 0, 64 );
 	}
 }

--- a/includes/class-wc-klarna-payments-order-lines.php
+++ b/includes/class-wc-klarna-payments-order-lines.php
@@ -385,7 +385,7 @@ class WC_Klarna_Payments_Order_Lines {
 		$order    = wc_get_order( $order_id );
 		$shipping = array(
 			'type'             => 'shipping_fee',
-			'reference'        => 1,
+			'reference'        => $this->get_order_shipping_reference( $order ),
 			'name'             => ( '' !== $order->get_shipping_method() ) ? $order->get_shipping_method() : $shipping_name = __( 'Shipping', 'klarna-payments-for-woocommerce' ),
 			'quantity'         => 1,
 			'unit_price'       => $this->get_order_shipping_unit_price( $order ),
@@ -892,5 +892,19 @@ class WC_Klarna_Payments_Order_Lines {
 			return 0;
 		}
 		return $order->get_shipping_tax() * 100;
+	}
+
+	/**
+	 * Get the order shipping reference
+	 *
+	 * @param object $order
+	 * @return void
+	 */
+	private function get_order_shipping_reference( $order ) {
+		$order_shipping_items = $order->get_items( 'shipping' );
+		foreach ( $order_shipping_items as $order_shipping_item ) {
+			$order_shipping_reference = $order_shipping_item->get_method_id() . ':' . $order_shipping_item->get_instance_id();
+		}
+		return $order_shipping_reference;
 	}
 }

--- a/includes/class-wc-klarna-payments-order-lines.php
+++ b/includes/class-wc-klarna-payments-order-lines.php
@@ -905,6 +905,11 @@ class WC_Klarna_Payments_Order_Lines {
 		foreach ( $order_shipping_items as $order_shipping_item ) {
 			$order_shipping_reference = $order_shipping_item->get_method_id() . ':' . $order_shipping_item->get_instance_id();
 		}
+
+		if ( ! isset( $order_shipping_reference ) ) {
+			$order_shipping_reference = __( 'Shipping', 'klarna-payments-for-woocommerce' );
+		}
+
 		return substr( strval( $order_shipping_reference ), 0, 64 );
 	}
 }

--- a/klarna-payments-for-woocommerce.php
+++ b/klarna-payments-for-woocommerce.php
@@ -5,7 +5,7 @@
  * Description: Provides Klarna Payments as payment method to WooCommerce.
  * Author: krokedil, klarna, automattic
  * Author URI: https://krokedil.com/
- * Version: 1.8.4
+ * Version: 1.9.0
  * Text Domain: klarna-payments-for-woocommerce
  * Domain Path: /languages
  *
@@ -35,7 +35,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Required minimums and constants
  */
-define( 'WC_KLARNA_PAYMENTS_VERSION', '1.8.4' );
+define( 'WC_KLARNA_PAYMENTS_VERSION', '1.9.0' );
 define( 'WC_KLARNA_PAYMENTS_MIN_PHP_VER', '5.6.0' );
 define( 'WC_KLARNA_PAYMENTS_MIN_WC_VER', '3.3.0' );
 define( 'WC_KLARNA_PAYMENTS_MAIN_FILE', __FILE__ );

--- a/readme.txt
+++ b/readme.txt
@@ -53,6 +53,12 @@ For help setting up and configuring Klarna Payments for WooCommerce please refer
 * A SSL Certificate is required.
 
 == Changelog ==
+= 2019.08.13  	- version 1.9.0 =
+* Feature       - Added support for WooCommerce Store Credit plugin.
+* Tweak         - Added console logging for Authorize ajax call.
+* Tweak         - Changed shipping reference logic for order data sent to Klarna. To be better compatible with future versions of Klarna Order Management plugin.
+* Fix           - Limit reference field sent to Klarna to 64 characters.
+
 = 2019.08.13  	- version 1.8.4 =
 * Fix           - Send address data to Klarna from checkout form on load call for US stores. Plugin rewrite caused payment method iframe not to be displayed for US stores.
 


### PR DESCRIPTION
* Feature - Added support for WooCommerce Store Credit plugin.
* Tweak - Added console logging for Authorize ajax call.
* Tweak - Changed shipping reference logic for order data sent to Klarna. To be better compatible with future versions of Klarna Order Management plugin.
* Fix - Limit reference field sent to Klarna to 64 characters.