### PR TITLE
Add support for log_to_db

### DIFF
--- a/classes/admin/class-kp-status.php
+++ b/classes/admin/class-kp-status.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * WooCommerce status page extension
+ *
+ * @class    KP_Status
+ * @package  KP/Classes
+ * @category Class
+ * @author   Krokedil
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+/**
+ * Class for WooCommerce status page.
+ */
+class KP_Status {
+	/**
+	 * Class constructor.
+	 */
+	public function __construct() {
+		add_action( 'woocommerce_system_status_report', array( $this, 'add_status_page_box' ) );
+	}
+
+	/**
+	 * Adds status page box for KP.
+	 *
+	 * @return void
+	 */
+	public function add_status_page_box() {
+		include_once WC_KLARNA_PAYMENTS_PLUGIN_PATH . '/includes/admin/views/status-report.php';
+	}
+}
+$kp_status = new KP_Status();

--- a/classes/class-kp-logger.php
+++ b/classes/class-kp-logger.php
@@ -34,6 +34,10 @@ class KP_Logger {
 			}
 			self::$log->add( 'klarna_payments', wp_json_encode( $message ) );
 		}
+
+		if ( isset( $data['response']['code'] ) && ( $data['response']['code'] < 200 || $data['response']['code'] > 299 ) ) {
+			self::log_to_db( $data );
+		}
 	}
 
 	/**
@@ -74,5 +78,23 @@ class KP_Logger {
 			'timestamp'      => date( 'Y-m-d H:i:s' ), // phpcs:ignore WordPress.DateTime.RestrictedFunctions -- Date is not used for display.
 			'plugin_version' => WC_KLARNA_PAYMENTS_VERSION,
 		);
+	}
+
+	/**
+	 * Logs an event in the WP DB.
+	 *
+	 * @param array $data The data to be logged.
+	 */
+	public static function log_to_db( $data ) {
+		$logs = get_option( 'krokedil_debuglog_kp', array() );
+
+		if ( ! empty( $logs ) ) {
+			$logs = json_decode( $logs );
+		}
+
+		$logs   = array_slice( $logs, -14 );
+		$logs[] = $data;
+		$logs   = wp_json_encode( $logs );
+		update_option( 'krokedil_debuglog_kp', $logs );
 	}
 }

--- a/includes/admin/views/status-report.php
+++ b/includes/admin/views/status-report.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Admin View: Page - Status Report.
+ *
+ * @package WC_Klarna_Payments\Includes\Admin\Views
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+?>
+<table class="wc_status_table widefat" cellspacing="0">
+	<thead>
+	<tr>
+		<th colspan="6" data-export-label="Klarna Payments Request Log">
+			<h2><?php esc_html_e( 'Klarna Payments', 'klarna-payments-for-woocommerce' ); ?><?php echo wc_help_tip( esc_html__( 'Klarna Payments System Status.', 'klarna-payments-for-woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></h2>
+		</th>
+	</tr>
+
+	<?php
+	$db_logs = get_option( 'krokedil_debuglog_kp', array() );
+	if ( ! empty( $db_logs ) ) {
+		$db_logs = array_reverse( json_decode( $db_logs, true ) );
+		?>
+			<tr>
+				<td ><strong><?php esc_html_e( 'Time', 'klarna-payments-for-woocommerce' ); ?></strong></td>
+				<td class="help"></td>
+				<td ><strong><?php esc_html_e( 'Request', 'klarna-payments-for-woocommerce' ); ?></strong></td>
+				<td ><strong><?php esc_html_e( 'Response Code', 'klarna-payments-for-woocommerce' ); ?></strong></td>
+				<td ><strong><?php esc_html_e( 'Response Message', 'klarna-payments-for-woocommerce' ); ?></strong></td>
+				<td ><strong><?php esc_html_e( 'Correlation ID', 'klarna-payments-for-woocommerce' ); ?></strong></td>
+			</tr>
+		</thead>
+		<tbody>
+		<?php
+		foreach ( $db_logs as $log ) {
+
+			$timestamp      = isset( $log['timestamp'] ) ? $log['timestamp'] : '';
+			$log_title      = isset( $log['title'] ) ? $log['title'] : '';
+			$code           = isset( $log['response']['code'] ) ? $log['response']['code'] : '';
+			$body           = isset( $log['response']['body'] ) ? wp_json_encode( $log['response']['body'] ) : '';
+			$error_code     = isset( $log['response']['body']['error_code'] ) ? 'Error code: ' . $log['response']['body']['error_code'] . '.' : '';
+			$error_messages = isset( $log['response']['body']['error_messages'] ) ? 'Error messages: ' . wp_json_encode( $log['response']['body']['error_messages'] ) : '';
+			$correlation_id = isset( $log['response']['body']['correlation_id'] ) ? $log['response']['body']['correlation_id'] : '';
+
+			?>
+			<tr>
+				<td><?php echo esc_html( $timestamp ); ?></td>
+				<td class="help"></td>
+				<td><?php echo esc_html( $log_title ); ?><span style="display: none;">, Response code: <?php echo esc_html( $code ); ?>, Response message: <?php echo esc_html( $body ); ?>, Correlation ID: <?php echo esc_html( $correlation_id ); ?></span</td>
+				<td><?php echo esc_html( $code ); ?></td>
+				<td><?php echo esc_html( $error_code ) . ' ' . esc_html( $error_messages ); ?></td>
+				<td><?php echo esc_html( $correlation_id ); ?></td>
+			</tr>
+			<?php
+		}
+	} else {
+		?>
+		</thead>
+		<tbody>
+			<tr>
+				<td colspan="6" data-export-label="No Klarna Payment errors"><?php esc_html_e( 'No error logs', 'klarna-payments-for-woocommerce' ); ?></td>
+			</tr>
+		<?php
+	}
+	?>
+		</tbody>
+	</table>

--- a/klarna-payments-for-woocommerce.php
+++ b/klarna-payments-for-woocommerce.php
@@ -212,6 +212,7 @@ if ( ! class_exists( 'WC_Klarna_Payments' ) ) {
 			include_once WC_KLARNA_PAYMENTS_PLUGIN_PATH . '/classes/class-kp-settings-saved.php';
 			include_once WC_KLARNA_PAYMENTS_PLUGIN_PATH . '/classes/class-kp-callbacks.php';
 			include_once WC_KLARNA_PAYMENTS_PLUGIN_PATH . '/classes/class-kp-checkout.php';
+			include_once WC_KLARNA_PAYMENTS_PLUGIN_PATH . '/classes/admin/class-kp-status.php';
 
 			// Requests.
 			include_once WC_KLARNA_PAYMENTS_PLUGIN_PATH . '/classes/requests/class-kp-requests.php';


### PR DESCRIPTION
We will now save the last 15 requests to Klarna that had an API error and display them on the WooCommerce status page. This should help with getting error messages when you need to debug issues without going through the logs. These will also be in the status report that you can send to us for support tickets.