### PR TITLE
Include $request_url into KP_Logger::format_log

### DIFF
--- a/classes/class-kp-logger.php
+++ b/classes/class-kp-logger.php
@@ -65,12 +65,13 @@ class KP_Logger {
 	 * @param string $code The status code.
 	 * @return array
 	 */
-	public static function format_log( $payment_id, $method, $title, $request_args, $response, $code ) {
+	public static function format_log( $payment_id, $method, $title, $request_args, $response, $code, $request_url = null ) {
 		return array(
 			'id'             => $payment_id,
 			'type'           => $method,
 			'title'          => $title,
 			'request'        => $request_args,
+			'request_url'    => $request_url,
 			'response'       => array(
 				'body' => $response,
 				'code' => $code,

--- a/classes/class-wc-gateway-klarna-payments.php
+++ b/classes/class-wc-gateway-klarna-payments.php
@@ -297,7 +297,7 @@ class WC_Gateway_Klarna_Payments extends WC_Payment_Gateway {
 		$session_id    = isset( $response_body['session_id'] ) ? $response_body['session_id'] : null;
 
 		// Log the request.
-		$log = WC_Klarna_Payments::format_log( $session_id, 'POST', 'Klarna Payments create session request.', $request_args, $response_body, $code );
+		$log = WC_Klarna_Payments::format_log( $session_id, 'POST', 'Klarna Payments create session request.', $request_args, $response_body, $code, $request_url );
 		WC_Klarna_Payments::log( $log );
 
 		if ( is_array( $response ) ) {

--- a/classes/requests/post/class-kp-create-session.php
+++ b/classes/requests/post/class-kp-create-session.php
@@ -29,7 +29,7 @@ class KP_Create_Session extends KP_Requests {
 		WC()->session->set( 'kp_update_md5', md5( wp_json_encode( $request_args ) ) );
 
 		// Log request.
-		$log = KP_Logger::format_log( $session_id, 'POST', 'KP Create Session', $request_args, $response, $code );
+		$log = KP_Logger::format_log( $session_id, 'POST', 'KP Create Session', $request_args, $response, $code, $request_url );
 		KP_Logger::log( $log );
 
 		$formated_response = $this->process_response( $response, $request_args, $request_url );

--- a/classes/requests/post/class-kp-place-order.php
+++ b/classes/requests/post/class-kp-place-order.php
@@ -28,7 +28,7 @@ class KP_Place_Order extends KP_Requests {
 		$order_id     = isset( $body['order_id'] ) ? $body['order_id'] : '';
 
 		// Log request.
-		$log = KP_Logger::format_log( $order_id, 'POST', 'KP Place Order', $request_args, $response, $code );
+		$log = KP_Logger::format_log( $order_id, 'POST', 'KP Place Order', $request_args, $response, $code, $request_url );
 		KP_Logger::log( $log );
 
 		$formated_response = $this->process_response( $response, $request_args, $request_url );

--- a/classes/requests/post/class-kp-test-credentials.php
+++ b/classes/requests/post/class-kp-test-credentials.php
@@ -30,7 +30,7 @@ class KP_Test_Credentials {
 		$code              = wp_remote_retrieve_response_code( $response );
 		$formated_response = $this->process_response( $response, $request_args, $request_url );
 		// Log the request.
-		$log = KP_Logger::format_log( null, 'POST', 'KP test credentials', $request_args, json_decode( wp_remote_retrieve_body( $response ), true ), $code );
+		$log = KP_Logger::format_log( null, 'POST', 'KP test credentials', $request_args, json_decode( wp_remote_retrieve_body( $response ), true ), $code, $request_url );
 		KP_Logger::log( $log );
 		return $formated_response;
 	}

--- a/classes/requests/post/class-kp-update-session.php
+++ b/classes/requests/post/class-kp-update-session.php
@@ -34,7 +34,7 @@ class KP_Update_Session extends KP_Requests {
 		$session_id = isset( $body['session_id'] ) ? $body['session_id'] : '';
 
 		// Log request.
-		$log = KP_Logger::format_log( $session_id, 'POST', 'KP Update Session', $request_args, $response, $code );
+		$log = KP_Logger::format_log( $session_id, 'POST', 'KP Update Session', $request_args, $response, $code, $request_url );
 		KP_Logger::log( $log );
 
 		$formated_response = $this->process_response( $response, $request_args, $request_url );


### PR DESCRIPTION
While debugging multiple mistakes on my client's website, I stumbled upon a problem that there's no way to identify request URL by WC logs left by Klarna Payments, rather than guessing by $title of the log data.

Now it logs url as well.