### PR TITLE
Fixed notice on check permalinks alert

### DIFF
--- a/klarna-payments-for-woocommerce.php
+++ b/klarna-payments-for-woocommerce.php
@@ -214,10 +214,7 @@ if ( ! class_exists( 'WC_Klarna_Payments' ) ) {
 								__( 'It looks as if you don\'t have pretty permalinks enabled in WordPress. In order for Klarna Payments for Woocommerce to function properly, this setting needs to be enabled. <a href="%1$s">Learn more</a>', 'klarna-payments-for-woocommerce' ),
 								esc_url( __( 'https://wordpress.org/support/article/using-permalinks/', 'klarna-payments-for-woocommerce' ) )
 							)
-						),
-						array(
-							'a' => array( 'href' => array() ),
-						) . '</p>'
+						)
 					);
 					?>
 					</div>


### PR DESCRIPTION
https://github.com/krokedil/klarna-payments-for-woocommerce/issues/239

Removed redundant code.

https://developer.wordpress.org/reference/functions/wp_kses_post/ - `wp_kses_post` only accepts one argument, the second is never used.