### PR TITLE
Do not autoload the debug log on WP start up

### DIFF
--- a/classes/class-kp-logger.php
+++ b/classes/class-kp-logger.php
@@ -97,6 +97,6 @@ class KP_Logger {
 		$logs   = array_slice( $logs, -14 );
 		$logs[] = $data;
 		$logs   = wp_json_encode( $logs );
-		update_option( 'krokedil_debuglog_kp', $logs );
+		update_option( 'krokedil_debuglog_kp', $logs, false );
 	}
 }


### PR DESCRIPTION
I've verified that the autoload attribute in the database is set to "no", the next time `update_option` is called.