### PR TITLE
Check if key exists before access

### DIFF
--- a/classes/class-kp-email.php
+++ b/classes/class-kp-email.php
@@ -31,7 +31,7 @@ if ( ! class_exists( 'KP_Email' ) ) {
 		public function add_klarna_data_to_mail( $order ) {
 			$gateway_used = $order->get_payment_method();
 			$settings     = get_option( 'woocommerce_klarna_payments_settings', array() );
-			$add_to_email = 'yes' === $settings['add_to_email'] ? true : false;
+			$add_to_email = ( isset( $settings['add_to_email'] ) && 'yes' === $settings['add_to_email'] ) ? true : false;
 			if ( 'klarna_payments' === $gateway_used && $add_to_email ) {
 				$klarna_cs_url  = '<a href="https://www.klarna.com/customer-service">' . esc_html__( 'Klarna', 'klarna-payments-for-woocommerce' ) . '</a>';
 				$klarna_app_url = '<a href="https://app.klarna.com/">' . esc_html__( 'Klarna App', 'klarna-payments-for-woocommerce' ) . '</a>';


### PR DESCRIPTION
Sometimes if the default empty array from get_option is returned, the missing key index would result in an undefined key notice (or warning).