### PR TITLE
Make KP available on admin page

### DIFF
--- a/classes/class-wc-gateway-klarna-payments.php
+++ b/classes/class-wc-gateway-klarna-payments.php
@@ -151,9 +151,6 @@ class WC_Gateway_Klarna_Payments extends WC_Payment_Gateway {
 	 * Check if Klarna Payments should be available
 	 */
 	public function is_available() {
-		if ( ! is_checkout() ) {
-			return false;
-		}
 		if ( 'yes' !== $this->enabled ) {
 			return false;
 		}


### PR DESCRIPTION
The woocommerce_available_payment_gateways hook check if `isEnabled` returns true. Since we're on the admin page when this hook is triggered by other plugins, `isEnabled` will return false.