### PR TITLE
Fix internal server error on different store-api regions

### DIFF
--- a/classes/class-wc-gateway-klarna-payments.php
+++ b/classes/class-wc-gateway-klarna-payments.php
@@ -290,7 +290,7 @@ class WC_Gateway_Klarna_Payments extends WC_Payment_Gateway {
 		$klarna_payments_params['order_pay_page']         = false;
 
 		// Maybe create KP Session.
-		if ( $this->is_available() ) {
+		if ( 'yes' === $this->enabled ) {
 			if ( is_wc_endpoint_url( 'order-pay' ) ) {
 				$key      = filter_input( INPUT_GET, 'key', FILTER_SANITIZE_STRING );
 				$order_id = wc_get_order_id_by_order_key( $key );


### PR DESCRIPTION
Klarna Payments may not be available when the checkout identifies the customer country on first render as not applicable for Klarna Payments (e.g., no API keys for that country) which results in the required parameters (e.g., "submit_order") not being included.

The issue is that when the customer switches to an API available country, the condition is not evaluated again (since enqueue_scripts has already been executed), resulting in an internal server error when trying to submit the order due to missing submit_order AJAX URL.