### PR TITLE
Support "input" #place_order tags

### DIFF
--- a/assets/js/klarna-payments.js
+++ b/assets/js/klarna-payments.js
@@ -544,7 +544,7 @@ jQuery( function($) {
 		klarna_payments.setRadioButtonValues();
 	});
 
-	$('body').on( 'click', 'button#place_order', function( e ) {
+	$('body').on( 'click', 'input#place_order, button#place_order', function( e ) {
 		if( "true" === klarna_payments_params.pay_for_order ) {
 			klarna_payments.klarnaPayForOrder( e );
 		} else {


### PR DESCRIPTION
Our WP theme use an input html tag with "place_order" id.
This small modification to also support _input_ tags increase compatibility and shouldn't create any problems.