### PR TITLE
Check if KP is enabled before processing order/cart

### DIFF
--- a/classes/class-wc-gateway-klarna-payments.php
+++ b/classes/class-wc-gateway-klarna-payments.php
@@ -277,6 +277,11 @@ class WC_Gateway_Klarna_Payments extends WC_Payment_Gateway {
 			return;
 		}
 
+		$settings = get_option( 'woocommerce_klarna_payments_settings', array() );
+		if ( ! isset( $settings['enabled'] ) || 'yes' !== $settings['enabled'] ) {
+			return;
+		}
+
 		// Localize the script.
 		$klarna_payments_params                           = array();
 		$klarna_payments_params['testmode']               = $this->get_option( 'testmode' );

--- a/includes/kp-functions.php
+++ b/includes/kp-functions.php
@@ -12,6 +12,11 @@
  * @return void|string
  */
 function kp_maybe_create_session_cart( $klarna_country = false ) {
+	$settings = get_option( 'woocommerce_klarna_payments_settings', array() );
+	if ( ! isset( $settings['enabled'] ) || 'yes' !== $settings['enabled'] ) {
+		return;
+	}
+
 	// Maybe calculate totals. Only once on a page load.
 	if ( ! is_ajax() && 0 >= did_action( 'woocommerce_before_calculate_totals' ) ) {
 		WC()->cart->calculate_fees();


### PR DESCRIPTION
Prevent KP from running if it is not enabled. This can happen if the plugin is activated, but the payment method is not enabled which may result in undefined index errors.

This change include check for redundancy so that we don't check if the plugin is enabled more than necessary.