### PR TITLE
Regenerate session data on fragment update and before submit

### DIFF
--- a/classes/class-kp-checkout.php
+++ b/classes/class-kp-checkout.php
@@ -27,6 +27,7 @@ class KP_Checkout {
 	 * @return array
 	 */
 	public function add_token_fragment( $fragments ) {
+		KP_WC()->session->set_session_data();
 		$session_token = KP_WC()->session->get_klarna_client_token();
 		if ( empty( $session_token ) ) {
 			return $fragments;
@@ -48,6 +49,7 @@ class KP_Checkout {
 	 */
 	public function html_client_token( $session_token = false ) {
 		if ( ! $session_token ) {
+			KP_WC()->session->set_session_data();
 			$session_token = KP_WC()->session->get_klarna_client_token();
 		}
 		?>

--- a/classes/class-kp-session.php
+++ b/classes/class-kp-session.php
@@ -107,11 +107,11 @@ class KP_Session {
 	/**
 	 * Sets session data from a WC session or order meta.
 	 *
-	 * @param WC_Order|int|null $order The WooCommerce order or order id. Null if we are working with a cart.
+	 * @param WC_Order|int|null $order The WooCommerce order or order id. Null if we are working with a cart (default).
 	 * @return void
 	 * @throws Exception If we get an error when trying to get the session data.
 	 */
-	public function set_session_data( $order ) {
+	public function set_session_data( $order = null ) {
 		// Maybe get the order from order id.
 		$order = $this->maybe_get_order( $order );
 


### PR DESCRIPTION
This fixes an issue where the `kp_client_token` is sometimes emptied by a third-party plugin.