### PR TITLE
Create new KP session on order-pay page

### DIFF
--- a/assets/js/klarna-payments.js
+++ b/assets/js/klarna-payments.js
@@ -544,8 +544,9 @@ jQuery( function($) {
 		klarna_payments.setRadioButtonValues();
 	});
 
-	$('body').on( 'click', 'input#place_order, button#place_order', function( e ) {
-		if( "true" === klarna_payments_params.pay_for_order ) {
+	$('body').on('click', 'input#place_order, button#place_order', function (e) {
+		// No strict comparison: wp_localize_script() converts booleans to strings "1", respectively, "0".
+		if( true == klarna_payments_params.pay_for_order ) {
 			klarna_payments.klarnaPayForOrder( e );
 		} else {
 			klarna_payments.orderSubmit( e );

--- a/classes/class-kp-assets.php
+++ b/classes/class-kp-assets.php
@@ -73,6 +73,10 @@ class KP_Assets {
 		$key           = $pay_for_order ? filter_input( INPUT_GET, 'key', FILTER_SANITIZE_SPECIAL_CHARS ) : null;
 		$order_id      = $pay_for_order ? wc_get_order_id_by_order_key( $key ) : null;
 
+		$customer_type = $settings['customer_type'] ?? 'b2c';
+		$order_data    = new KP_Order_Data( $customer_type );
+		$customer      = $order_data->get_klarna_customer_object();
+
 		// Create the params array.
 		$klarna_payments_params = array(
 			// Ajax URLS.
@@ -88,15 +92,15 @@ class KP_Assets {
 			'submit_order'           => WC_AJAX::get_endpoint( 'checkout' ),
 			// Params.
 			'testmode'               => $settings['testmode'] ?? 'no',
-			'customer_type'          => $settings['customer_type'] ?? 'b2c',
+			'customer_type'          => $customer_type,
 			'remove_postcode_spaces' => ( apply_filters( 'wc_kp_remove_postcode_spaces', false ) ) ? 'yes' : 'no',
 			'client_token'           => KP_WC()->session->get_klarna_client_token(),
 			'order_pay_page'         => $pay_for_order,
 			'pay_for_order'          => $pay_for_order,
 			'order_id'               => $order_id,
 			'addresses'              => $pay_for_order ? array(
-				'billing'  => WC()->customer->get_billing_address(),
-				'shipping' => WC()->customer->get_shipping_address(),
+				'billing'  => $customer['billing'],
+				'shipping' => $customer['shipping'],
 			) : null,
 		);
 

--- a/classes/class-kp-checkout.php
+++ b/classes/class-kp-checkout.php
@@ -18,6 +18,7 @@ class KP_Checkout {
 	public function __construct() {
 		add_filter( 'woocommerce_update_order_review_fragments', array( $this, 'add_token_fragment' ) );
 		add_action( 'woocommerce_review_order_before_submit', array( $this, 'html_client_token' ) );
+		add_action( 'woocommerce_pay_order_before_submit', array( $this, 'html_client_token' ) );
 	}
 
 	/**

--- a/templates/klarna-payments-categories.php
+++ b/templates/klarna-payments-categories.php
@@ -4,6 +4,14 @@
  *
  * @package WC_Klarna_Payments/Templates
  */
+if ( kp_is_order_pay_page() ) {
+	$key      = filter_input( INPUT_GET, 'key', FILTER_SANITIZE_STRING );
+	$order_id = wc_get_order_id_by_order_key( $key );
+	$order    = wc_get_order( $order_id );
+
+	// Create a new session as 'woocommerce_after_calculate_totals' is only triggered on the cart (and checkout) page.
+	KP_WC()->session->get_session( $order );
+}
 
 $payment_categories = KP_WC()->session->get_klarna_payment_method_categories();
 


### PR DESCRIPTION
On `order-pay` page:
- create a new KP session from the `WC_Order`
- inject the `kp_client_token`
- pass the _full_ billing and shipping address (previously only street address) in checkout params
- do not use strict comparison when checking for Boolean value in checkout params