### PR TITLE
Ensure arrays contain only numeric items before using `array_sum`

### DIFF
--- a/classes/class-kp-session.php
+++ b/classes/class-kp-session.php
@@ -251,8 +251,13 @@ class KP_Session {
 	 * @return string
 	 */
 	private function get_session_cart_hash() {
+		// The `get_totals` method can return non-numeric items which should be removed before using `array_sum`.
+		$cart_totals = array_filter( WC()->cart->get_totals(), function( $total ) {
+			return is_numeric( $total );
+		} );
+
 		// Get values to use for the combined hash calculation.
-		$total            = array_sum( WC()->cart->get_totals() );
+		$total            = array_sum( $cart_totals );
 		$billing_address  = WC()->customer->get_billing();
 		$shipping_address = WC()->customer->get_shipping();
 		$shipping_method  = WC()->session->get( 'chosen_shipping_methods' );


### PR DESCRIPTION
Hey there,

I've been experiencing a problem with this plugin on a site we maintain.

Inside the `class-kp-session.php` file on line 255, the `array_sum` function crashes with the following exception:

```
PHP Fatal error:  Uncaught Error: Unsupported operand types in .../wp-content/plugins/klarna-payments-for-woocommerce/classes/class-kp-session.php:255
```

From my understanding, the `array_sum` function is expected to skip non-numeric items but in this case it's throwing an exception because one of the items inside `WC()->cart->get_totals()` has been iterated over using the `next` function.

Iterating over an array using functions like `next` swaps it with an array reference to the current item, and the `array_sum` function doesn't skip array references which results in an exception as array references can't be added to numeric values.

I opened [an issue](https://github.com/php/php-src/issues/10725) with the PHP maintainers about this in which they informed me about [this RFC](https://wiki.php.net/rfc/saner-array-sum-product) that changes the behaviour of both the `array_sum` and `array_product` functions in such a way that would fix this error.

To fix this error for PHP < 8.3, and to prevent warnings from being emitted in PHP >= 8.3, I've come up with this solution which is running in production on the aforementioned site.

Thanks!