### PR TITLE
Add meta data required for order management

### DIFF
--- a/classes/class-kp-ajax.php
+++ b/classes/class-kp-ajax.php
@@ -83,7 +83,6 @@ if ( ! class_exists( 'KP_AJAX' ) ) {
 					wp_send_json_error( $order->get_cancel_order_url_raw() );
 					break;
 			}
-			wp_send_json_success();
 		}
 
 		/**

--- a/classes/class-kp-ajax.php
+++ b/classes/class-kp-ajax.php
@@ -67,17 +67,21 @@ if ( ! class_exists( 'KP_AJAX' ) ) {
 					kp_process_accepted( $order, $response );
 					kp_unset_session_values();
 					wp_send_json_success( $response['redirect_url'] );
+					break;
 				case 'PENDING':
 					kp_process_pending( $order, $response );
 					kp_unset_session_values();
 					wp_send_json_success( $response['redirect_url'] );
+					break;
 				case 'REJECTED':
 					kp_process_rejected( $order, $response );
 					kp_unset_session_values();
 					wp_send_json_error( $order->get_cancel_order_url_raw() );
+					break;
 				default:
 					kp_unset_session_values();
 					wp_send_json_error( $order->get_cancel_order_url_raw() );
+					break;
 			}
 		}
 

--- a/classes/class-kp-ajax.php
+++ b/classes/class-kp-ajax.php
@@ -67,21 +67,17 @@ if ( ! class_exists( 'KP_AJAX' ) ) {
 					kp_process_accepted( $order, $response );
 					kp_unset_session_values();
 					wp_send_json_success( $response['redirect_url'] );
-					break;
 				case 'PENDING':
 					kp_process_pending( $order, $response );
 					kp_unset_session_values();
 					wp_send_json_success( $response['redirect_url'] );
-					break;
 				case 'REJECTED':
 					kp_process_rejected( $order, $response );
 					kp_unset_session_values();
 					wp_send_json_error( $order->get_cancel_order_url_raw() );
-					break;
 				default:
 					kp_unset_session_values();
 					wp_send_json_error( $order->get_cancel_order_url_raw() );
-					break;
 			}
 		}
 

--- a/includes/kp-functions.php
+++ b/includes/kp-functions.php
@@ -9,7 +9,7 @@
  * Unsets all Klarna Payments sessions.
  */
 function kp_unset_session_values() {
-	if( ! WC()->session ) {
+	if ( ! WC()->session ) {
 		return;
 	}
 
@@ -65,6 +65,27 @@ function kp_get_klarna_country( $order = false ) {
 }
 
 /**
+ * Process authorization or callback response for accepted or pending Klarna orders.
+ *
+ * @param WC_Order $order WooCommerce order.
+ * @param array    $decoded Klarna authorization or callback response.
+ *
+ * @return void
+ */
+function kp_process_auth_or_callback( $order, $response ) {
+
+	$environment = 'yes' === get_option( 'woocommerce_klarna_payments_settings' )['testmode'] ? 'playground' : 'production';
+
+	$order->update_meta_data( '_wc_klarna_environment', $environment ? 'test' : 'live' );
+	$order->update_meta_data( '_wc_klarna_country', kp_get_klarna_country( $order ) );
+	$order->update_meta_data( '_wc_klarna_order_id', $response['order_id'], true );
+	$order->update_meta_data( '_transaction_id', $response['order_id'], true );
+	$order->update_meta_data( '_payment_method', $order->get_payment_method() );
+	$order->update_meta_data( '_payment_method_title', 'Klarna' );
+	$order->save();
+}
+
+/**
  * Process accepted Klarna Payments order.
  *
  * @param WC_Order $order WooCommerce order.
@@ -76,11 +97,10 @@ function kp_process_accepted( $order, $decoded ) {
 	$kp_gateway = new WC_Gateway_Klarna_Payments();
 	$order->payment_complete( $decoded['order_id'] );
 	$order->add_order_note( 'Payment via Klarna Payments, order ID: ' . $decoded['order_id'] );
-	update_post_meta( $order->get_id(), '_wc_klarna_order_id', $decoded['order_id'], true );
-	update_post_meta( $order->get_id(), '_payment_method', 'klarna_payments' );
-	update_post_meta( $order->get_id(), '_payment_method_title', 'Klarna' );
+	kp_process_auth_or_callback( $order, $decoded );
 	do_action( 'wc_klarna_payments_accepted', $order->get_id(), $decoded );
 	do_action( 'wc_klarna_accepted', $order->get_id(), $decoded );
+
 	return array(
 		'result'   => 'success',
 		'redirect' => $kp_gateway->get_return_url( $order ),
@@ -98,8 +118,7 @@ function kp_process_accepted( $order, $decoded ) {
 function kp_process_pending( $order, $decoded ) {
 	$kp_gateway = new WC_Gateway_Klarna_Payments();
 	$order->update_status( 'on-hold', 'Klarna order is under review, order ID: ' . $decoded['order_id'] );
-	update_post_meta( $order->get_id(), '_wc_klarna_order_id', $decoded['order_id'], true );
-	update_post_meta( $order->get_id(), '_transaction_id', $decoded['order_id'], true );
+	kp_process_auth_or_callback( $order, $decoded );
 	do_action( 'wc_klarna_payments_pending', $order->get_id(), $decoded );
 	do_action( 'wc_klarna_pending', $order->get_id(), $decoded );
 	return array(


### PR DESCRIPTION
- `kp_process_auth_or_callback` add the necessary meta data required for order management.
- **remove dead code:** the `default` case contain a `wp_send_json_error` which will terminate with a `wp_die` or `die` when internally calling `wp_send_json` thus never reaching the `wp_send_json_success` that follows the switch case.
- **remove redundant code:** A `wp_send_json` will always terminate with `wp_die` or `die`, thus making the `break` redundant.

Reference: https://developer.wordpress.org/reference/functions/wp_send_json/