### PR TITLE
Fix "What is Klarna" checkbox double negation

### DIFF
--- a/classes/class-wc-gateway-klarna-payments.php
+++ b/classes/class-wc-gateway-klarna-payments.php
@@ -83,7 +83,7 @@ class WC_Gateway_Klarna_Payments extends WC_Payment_Gateway {
 		$this->testmode      = 'yes' === $this->get_option( 'testmode' );
 
 		// What is Klarna link.
-		$this->hide_what_is_klarna  = 'yes' !== $this->get_option( 'hide_what_is_klarna' );
+		$this->hide_what_is_klarna  = 'yes' === $this->get_option( 'hide_what_is_klarna' );
 		$this->float_what_is_klarna = 'yes' === $this->get_option( 'float_what_is_klarna' );
 
 		// Hooks.


### PR DESCRIPTION
Contrary to what is expected, when the checkbox is checked, we should not show "What is Klarna". This PR restores this behavior.

Related task: https://app.clickup.com/t/865cuapjq