### PR TITLE
Make countries in settings in alphabetic order

### DIFF
--- a/classes/admin/class-kp-form-fields.php
+++ b/classes/admin/class-kp-form-fields.php
@@ -52,11 +52,7 @@ class KP_Form_Fields {
 			'currency' => 'DKK',
 			'endpoint' => '',
 		),
-		'de' => array(
-			'name'     => 'Germany',
-			'currency' => 'EUR',
-			'endpoint' => '',
-		),
+
 		'fi' => array(
 			'name'     => 'Finland',
 			'currency' => 'EUR',
@@ -64,6 +60,11 @@ class KP_Form_Fields {
 		),
 		'fr' => array(
 			'name'     => 'France',
+			'currency' => 'EUR',
+			'endpoint' => '',
+		),
+		'de' => array(
+			'name'     => 'Germany',
 			'currency' => 'EUR',
 			'endpoint' => '',
 		),
@@ -87,14 +88,14 @@ class KP_Form_Fields {
 			'currency' => 'EUR',
 			'endpoint' => '',
 		),
+		'mx' => array(
+			'name'     => 'Mexico',
+			'currency' => 'MXN',
+			'endpoint' => '-na',
+		),
 		'nl' => array(
 			'name'     => 'Netherlands',
 			'currency' => 'EUR',
-			'endpoint' => '',
-		),
-		'no' => array(
-			'name'     => 'Norway',
-			'currency' => 'NOK',
 			'endpoint' => '',
 		),
 		'nz' => array(
@@ -102,11 +103,12 @@ class KP_Form_Fields {
 			'currency' => 'NZD',
 			'endpoint' => '-oc',
 		),
-		'mx' => array(
-			'name'     => 'Mexico',
-			'currency' => 'MXN',
-			'endpoint' => '-na',
+		'no' => array(
+			'name'     => 'Norway',
+			'currency' => 'NOK',
+			'endpoint' => '',
 		),
+
 		'pl' => array(
 			'name'     => 'Poland',
 			'currency' => 'PLN',
@@ -117,14 +119,14 @@ class KP_Form_Fields {
 			'currency' => 'EUR',
 			'endpoint' => '',
 		),
-		'es' => array(
-			'name'     => 'Spain',
-			'currency' => 'EUR',
-			'endpoint' => '',
-		),
 		'ro' => array(
 			'name'     => 'Romania',
 			'currency' => 'RON',
+			'endpoint' => '',
+		),
+		'es' => array(
+			'name'     => 'Spain',
+			'currency' => 'EUR',
 			'endpoint' => '',
 		),
 		'se' => array(


### PR DESCRIPTION
Countries should be in the following order:

```
 Australia
 Austria
 Belgium
 Canada
 Czech Republic
 Denmark
 Finland
 France
 Germany
 Greece
 Hungary
 Ireland
 Italy
 Mexico
 Netherlands
 New Zealand
 Norway
 Poland
 Portugal
 Romania
 Spain
 Sweden
 Switzerland
 United Kingdom
 United States
 ```

Previously, we ordered them based on array key rather than name value.