### PR TITLE
Prevent further order processing once processed once

### DIFF
--- a/classes/class-kp-ajax.php
+++ b/classes/class-kp-ajax.php
@@ -55,6 +55,12 @@ if ( ! class_exists( 'KP_AJAX' ) ) {
 			}
 
 			$order = wc_get_order( $order_id );
+
+			// Prevent further processing if the order has already been processed once.
+			if ( ! empty( $order->get_date_paid() ) ) {
+				wp_send_json_success( $order->get_checkout_order_received_url() );
+			}
+
 			$recurring_token = false;
 
 			if ( KP_Subscription::order_has_subscription( $order ) ) {


### PR DESCRIPTION
Check if the order has already been processed once. Unlike `WC_Order::is_paid` which is false unless the order status is processing or completed, `WC_Order::get_date_paid` is true if the payment has been completed which covers cases for when the order status is cancelled or refunded.

We could also check for the existence of `_wc_klarna_order_id`, however, that might not be set if the place order is rejected.