### PR TITLE
[Performance] Use order id from url in order-pay instead of order key.

### DIFF
--- a/classes/class-kp-assets.php
+++ b/classes/class-kp-assets.php
@@ -71,8 +71,7 @@ class KP_Assets {
 	private function get_checkout_params( $settings ) {
 		// Set needed variables for the order pay page handling.
 		$pay_for_order = kp_is_order_pay_page();
-		$key           = $pay_for_order ? filter_input( INPUT_GET, 'key', FILTER_SANITIZE_SPECIAL_CHARS ) : null;
-		$order_id      = $pay_for_order ? wc_get_order_id_by_order_key( $key ) : null;
+		$order_id      = $pay_for_order ? absint( get_query_var( 'order-pay' ) ) : null;
 
 		$customer_type = $settings['customer_type'] ?? 'b2c';
 		$order_data    = new KP_Order_Data( $customer_type, $order_id );

--- a/templates/klarna-payments-categories.php
+++ b/templates/klarna-payments-categories.php
@@ -5,8 +5,7 @@
  * @package WC_Klarna_Payments/Templates
  */
 if ( kp_is_order_pay_page() ) {
-	$key      = filter_input( INPUT_GET, 'key', FILTER_SANITIZE_STRING );
-	$order_id = wc_get_order_id_by_order_key( $key );
+	$order_id = absint( get_query_var( 'order-pay' ) );
 	$order    = wc_get_order( $order_id );
 
 	// Create a new session as 'woocommerce_after_calculate_totals' is only triggered on the cart (and checkout) page.


### PR DESCRIPTION
For large databases `wc_get_order_id_by_order_key ` takes a long time.


<img width="858" alt="283413934-884ea0ec-2922-47cf-acc6-e27475a721ed" src="https://github.com/krokedil/klarna-payments-for-woocommerce/assets/12052390/7511241c-21fe-46eb-bf89-f83079248c44">
