### PR TITLE
Version 1.4.0

### DIFF
--- a/classes/class-kp-klarna-express-checkout.php
+++ b/classes/class-kp-klarna-express-checkout.php
@@ -26,10 +26,36 @@ class KP_Klarna_Express_Checkout {
 	 * @return void
 	 */
 	public function __construct() {
-		$this->klarna_express_checkout = new KlarnaExpressCheckout();
+		$this->klarna_express_checkout = new KlarnaExpressCheckout( 'woocommerce_klarna_payments_settings', kp_get_locale() );
 
 		$this->klarna_express_checkout->ajax()->set_get_payload( array( $this, 'get_payload' ) );
 		$this->klarna_express_checkout->ajax()->set_finalize_callback( array( $this, 'finalize_callback' ) );
+
+		add_filter( 'wc_klarna_payments_supports', array( $this, 'maybe_add_pay_button_support' ) );
+	}
+
+	/**
+	 * Maybe add pay button support.
+	 *
+	 * @param array $supports The supports array.
+	 *
+	 * @return array
+	 */
+	public function maybe_add_pay_button_support( $supports ) {
+		if ( $this->is_enabled() ) {
+			$supports[] = 'pay_button';
+		}
+
+		return $supports;
+	}
+
+	/**
+	 * Returns if KEC is enabled or not.
+	 *
+	 * @return bool
+	 */
+	public function is_enabled() {
+		return $this->klarna_express_checkout->settings()->is_enabled();
 	}
 
 	/**

--- a/classes/class-wc-gateway-klarna-payments.php
+++ b/classes/class-wc-gateway-klarna-payments.php
@@ -69,7 +69,6 @@ class WC_Gateway_Klarna_Payments extends WC_Payment_Gateway {
 			'wc_klarna_payments_supports',
 			array(
 				'products',
-				'pay_button',
 				'subscriptions',
 				'subscription_cancellation',
 				'subscription_suspension',

--- a/composer.lock
+++ b/composer.lock
@@ -71,16 +71,16 @@
         },
         {
             "name": "krokedil/klarna-express-checkout",
-            "version": "1.2.1",
+            "version": "1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/krokedil/klarna-express-checkout.git",
-                "reference": "617307a03c8a93ec40981394327d2f002c770680"
+                "reference": "33792357ba3884044e90a02b8e24ebd9c945422d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/krokedil/klarna-express-checkout/zipball/617307a03c8a93ec40981394327d2f002c770680",
-                "reference": "617307a03c8a93ec40981394327d2f002c770680",
+                "url": "https://api.github.com/repos/krokedil/klarna-express-checkout/zipball/33792357ba3884044e90a02b8e24ebd9c945422d",
+                "reference": "33792357ba3884044e90a02b8e24ebd9c945422d",
                 "shasum": ""
             },
             "require": {
@@ -136,10 +136,10 @@
             ],
             "description": "A Klarna Express Checkout solution for WooCommerce",
             "support": {
-                "source": "https://github.com/krokedil/klarna-express-checkout/tree/1.2.1",
+                "source": "https://github.com/krokedil/klarna-express-checkout/tree/1.3.0",
                 "issues": "https://github.com/krokedil/klarna-express-checkout/issues"
             },
-            "time": "2024-01-16T06:25:48+00:00"
+            "time": "2024-01-31T07:58:09+00:00"
         },
         {
             "name": "krokedil/woocommerce",
@@ -322,12 +322,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "ff2765d764b8feac7d9c7c71f5948d679d44a3a8"
+                "reference": "2fbf9e38ef3307d740de375b8d2f19fc1dd19472"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/ff2765d764b8feac7d9c7c71f5948d679d44a3a8",
-                "reference": "ff2765d764b8feac7d9c7c71f5948d679d44a3a8",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/2fbf9e38ef3307d740de375b8d2f19fc1dd19472",
+                "reference": "2fbf9e38ef3307d740de375b8d2f19fc1dd19472",
                 "shasum": ""
             },
             "require": {
@@ -395,7 +395,7 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2024-01-15T09:13:36+00:00"
+            "time": "2024-01-29T05:54:15+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",

--- a/klarna-payments-for-woocommerce.php
+++ b/klarna-payments-for-woocommerce.php
@@ -5,12 +5,12 @@
  * Description: Provides Klarna Payments as payment method to WooCommerce.
  * Author: klarna
  * Author URI: https://www.klarna.com/
- * Version: 3.3.1
+ * Version: 3.4.0
  * Text Domain: klarna-payments-for-woocommerce
  * Domain Path: /languages
  *
  * WC requires at least: 5.6.0
- * WC tested up to: 8.3.1
+ * WC tested up to: 8.5.2
  *
  * Copyright (c) 2017-2024 Krokedil
  *
@@ -39,7 +39,7 @@ use KlarnaPayments\Blocks\Payments\KlarnaPayments;
 /**
  * Required minimums and constants
  */
-define( 'WC_KLARNA_PAYMENTS_VERSION', '3.3.1' );
+define( 'WC_KLARNA_PAYMENTS_VERSION', '3.4.0' );
 define( 'WC_KLARNA_PAYMENTS_MIN_PHP_VER', '7.4.0' );
 define( 'WC_KLARNA_PAYMENTS_MIN_WC_VER', '5.6.0' );
 define( 'WC_KLARNA_PAYMENTS_MAIN_FILE', __FILE__ );

--- a/readme.txt
+++ b/readme.txt
@@ -6,8 +6,8 @@ Requires at least: 5.0
 Tested up to: 6.4.2
 Requires PHP: 7.4
 WC requires at least: 5.6.0
-WC tested up to: 8.5.0
-Stable tag: 3.3.1
+WC tested up to: 8.5.2
+Stable tag: 3.4.0
 License: GPLv3 or later
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -51,6 +51,11 @@ For help setting up and configuring Klarna Payments for WooCommerce please refer
 
 
 == Changelog ==
+= 2024.01.31    - version 3.4.0 =
+* Feature       - Add support to pass locale to Klarna Express Checkout.
+* Fix           - Klarna Express Checkout will no longer compare the shipping address to the KEC provided address when delivery address is forced to be the billing address.
+* Fix           - Fixed an issue with WooCommerce Subscriptions that would cause a recursion error when canceling a subscription with a Klarna Payments payment method.
+
 = 2024.01.16    - version 3.3.1 =
 * Fix           - Remove the required flag from the KEC client identifier setting.
 


### PR DESCRIPTION
* Feature - Add support to pass locale to Klarna Express Checkout.
* Fix - Klarna Express Checkout will no longer compare the shipping address to the KEC provided address when delivery address is forced to be the billing address.
* Fix - Fixed an issue with WooCommerce Subscriptions that would cause a recursion error when canceling a subscription with a Klarna Payments payment method.