### PR TITLE
Explicitly set the payment method

### DIFF
--- a/classes/class-kp-subscriptions.php
+++ b/classes/class-kp-subscriptions.php
@@ -82,7 +82,7 @@ class KP_Subscription {
 		if ( ! is_wp_error( $response ) ) {
 			$klarna_order_id = $response['order_id'];
 			$renewal_order->add_order_note( sprintf( __( 'Subscription payment made with Klarna. Klarna order id: %s', 'klarna-payments-for-woocommerce' ), $klarna_order_id ) );
-			self::save_order_meta_data( $renewal_order, $response );
+			kp_save_order_meta_data( $renewal_order, $response );
 		} else {
 			$error_message = $response->get_error_message();
 			// Translators: Error message.
@@ -328,25 +328,7 @@ class KP_Subscription {
 		return isset( $_GET['change_payment_method'] );
 	}
 
-	/**
-	 * Process the response from a Klarna request to store meta data about an order.
-	 *
-	 * @param WC_Order $renewal_order The WooCommerce order.
-	 * @param array    $response Response from Klarna request that contain order details.
-	 *
-	 * @return void
-	 */
-	public static function save_order_meta_data( $order, $response ) {
-		$environment = 'yes' === get_option( 'woocommerce_klarna_payments_settings' )['testmode'] ? 'test' : 'live';
 
-		$order->update_meta_data( '_wc_klarna_environment', $environment );
-		$order->update_meta_data( '_wc_klarna_country', kp_get_klarna_country( $order ) );
-		$order->update_meta_data( '_wc_klarna_order_id', $response['order_id'], true );
-		$order->set_transaction_id( $response['order_id'] );
-		$order->set_payment_method_title( 'Klarna' );
-
-		$order->save();
-	}
 
 	/**
 	 * Check if an order contains a subscription.


### PR DESCRIPTION
Seems like WC is not updating the payment method when a pending payment order is paid through the order pay page using a different payment gateway.

- explicitly set the payment method.
- **refactor:** `save_order_meta_data` in subscriptions is identical to `kp_process_auth_or_callback`. To avoid repeating ourselves, I've consolidated both functions into `kp_save_order_meta_data`.