### PR TITLE
Version 3.4.1

### DIFF
--- a/classes/class-kp-subscriptions.php
+++ b/classes/class-kp-subscriptions.php
@@ -82,7 +82,7 @@ class KP_Subscription {
 		if ( ! is_wp_error( $response ) ) {
 			$klarna_order_id = $response['order_id'];
 			$renewal_order->add_order_note( sprintf( __( 'Subscription payment made with Klarna. Klarna order id: %s', 'klarna-payments-for-woocommerce' ), $klarna_order_id ) );
-			self::save_order_meta_data( $renewal_order, $response );
+			kp_save_order_meta_data( $renewal_order, $response );
 		} else {
 			$error_message = $response->get_error_message();
 			// Translators: Error message.
@@ -328,25 +328,7 @@ class KP_Subscription {
 		return isset( $_GET['change_payment_method'] );
 	}
 
-	/**
-	 * Process the response from a Klarna request to store meta data about an order.
-	 *
-	 * @param WC_Order $renewal_order The WooCommerce order.
-	 * @param array    $response Response from Klarna request that contain order details.
-	 *
-	 * @return void
-	 */
-	public static function save_order_meta_data( $order, $response ) {
-		$environment = 'yes' === get_option( 'woocommerce_klarna_payments_settings' )['testmode'] ? 'test' : 'live';
 
-		$order->update_meta_data( '_wc_klarna_environment', $environment );
-		$order->update_meta_data( '_wc_klarna_country', kp_get_klarna_country( $order ) );
-		$order->update_meta_data( '_wc_klarna_order_id', $response['order_id'], true );
-		$order->set_transaction_id( $response['order_id'] );
-		$order->set_payment_method_title( 'Klarna' );
-
-		$order->save();
-	}
 
 	/**
 	 * Check if an order contains a subscription.

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "require": {
     "krokedil/wp-api": "^1.0",
-    "krokedil/woocommerce": "^1.3",
+    "krokedil/woocommerce": "^1.5",
     "krokedil/klarna-express-checkout": "^1.2.0"
   },
   "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "978a7f69a01f9c4fcbbf8dc44f854acd",
+    "content-hash": "24f0d4679600025e0b26bc068b68cfb8",
     "packages": [
         {
             "name": "firebase/php-jwt",
@@ -143,16 +143,16 @@
         },
         {
             "name": "krokedil/woocommerce",
-            "version": "1.4.0",
+            "version": "1.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/krokedil/woocommerce.git",
-                "reference": "11a6ac25cdab496a169a1ea1fc6c17594579634c"
+                "reference": "0f92aa008d8af7236094dc52497af7ae62f53937"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/krokedil/woocommerce/zipball/11a6ac25cdab496a169a1ea1fc6c17594579634c",
-                "reference": "11a6ac25cdab496a169a1ea1fc6c17594579634c",
+                "url": "https://api.github.com/repos/krokedil/woocommerce/zipball/0f92aa008d8af7236094dc52497af7ae62f53937",
+                "reference": "0f92aa008d8af7236094dc52497af7ae62f53937",
                 "shasum": ""
             },
             "require-dev": {
@@ -177,10 +177,10 @@
             ],
             "description": "A library package for Krokedils plugins that contains helper methods when working with WooCommerce.",
             "support": {
-                "source": "https://github.com/krokedil/woocommerce/tree/1.4.0",
+                "source": "https://github.com/krokedil/woocommerce/tree/1.5.0",
                 "issues": "https://github.com/krokedil/woocommerce/issues"
             },
-            "time": "2024-01-08T08:08:25+00:00"
+            "time": "2024-03-12T13:13:23+00:00"
         },
         {
             "name": "krokedil/wp-api",
@@ -322,12 +322,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "2fbf9e38ef3307d740de375b8d2f19fc1dd19472"
+                "reference": "9905515ecd59bbc4da0dca897676f2b04683beec"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/2fbf9e38ef3307d740de375b8d2f19fc1dd19472",
-                "reference": "2fbf9e38ef3307d740de375b8d2f19fc1dd19472",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/9905515ecd59bbc4da0dca897676f2b04683beec",
+                "reference": "9905515ecd59bbc4da0dca897676f2b04683beec",
                 "shasum": ""
             },
             "require": {
@@ -395,7 +395,7 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2024-01-29T05:54:15+00:00"
+            "time": "2024-03-08T21:27:43+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",
@@ -456,5 +456,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/klarna-payments-for-woocommerce.php
+++ b/klarna-payments-for-woocommerce.php
@@ -5,7 +5,7 @@
  * Description: Provides Klarna Payments as payment method to WooCommerce.
  * Author: klarna
  * Author URI: https://www.klarna.com/
- * Version: 3.4.0
+ * Version: 3.4.1
  * Text Domain: klarna-payments-for-woocommerce
  * Domain Path: /languages
  *
@@ -39,7 +39,7 @@ use KlarnaPayments\Blocks\Payments\KlarnaPayments;
 /**
  * Required minimums and constants
  */
-define( 'WC_KLARNA_PAYMENTS_VERSION', '3.4.0' );
+define( 'WC_KLARNA_PAYMENTS_VERSION', '3.4.1' );
 define( 'WC_KLARNA_PAYMENTS_MIN_PHP_VER', '7.4.0' );
 define( 'WC_KLARNA_PAYMENTS_MIN_WC_VER', '5.6.0' );
 define( 'WC_KLARNA_PAYMENTS_MAIN_FILE', __FILE__ );

--- a/klarna-payments-for-woocommerce.php
+++ b/klarna-payments-for-woocommerce.php
@@ -5,12 +5,12 @@
  * Description: Provides Klarna Payments as payment method to WooCommerce.
  * Author: klarna
  * Author URI: https://www.klarna.com/
- * Version: 3.3.1
+ * Version: 3.4.0
  * Text Domain: klarna-payments-for-woocommerce
  * Domain Path: /languages
  *
  * WC requires at least: 5.6.0
- * WC tested up to: 8.3.1
+ * WC tested up to: 8.5.2
  *
  * Copyright (c) 2017-2024 Krokedil
  *
@@ -39,7 +39,7 @@ use KlarnaPayments\Blocks\Payments\KlarnaPayments;
 /**
  * Required minimums and constants
  */
-define( 'WC_KLARNA_PAYMENTS_VERSION', '3.3.1' );
+define( 'WC_KLARNA_PAYMENTS_VERSION', '3.4.0' );
 define( 'WC_KLARNA_PAYMENTS_MIN_PHP_VER', '7.4.0' );
 define( 'WC_KLARNA_PAYMENTS_MIN_WC_VER', '5.6.0' );
 define( 'WC_KLARNA_PAYMENTS_MAIN_FILE', __FILE__ );

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "klarna-payments-for-woocommerce",
-  "version": "3.3.1",
+  "version": "3.4.1",
   "description": "Klarna Payments for WooCommerce",
   "main": "gulpfile.js",
   "repository": "https://github.com/krokedil/klarna-payments-for-woocommerce.git",

--- a/readme.txt
+++ b/readme.txt
@@ -7,7 +7,7 @@ Tested up to: 6.4.2
 Requires PHP: 7.4
 WC requires at least: 5.6.0
 WC tested up to: 8.5.2
-Stable tag: 3.4.0
+Stable tag: 3.4.1
 License: GPLv3 or later
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -51,6 +51,11 @@ For help setting up and configuring Klarna Payments for WooCommerce please refer
 
 
 == Changelog ==
+= 2024.03.12    - version 3.4.1 =
+* Fix           - Fixed an issue where the name of the previous payment gateway was set on the order after changing to, and paying with Klarna Payments.
+* Fix           - Setting multiple tax rates with different priorities in WooCommerce tax settings should now work as expected.
+* Fix           - Fixed an issue introduced in WooCommerce version 8.7.0 where a critical error would occur if the cart contained any coupon.
+
 = 2024.01.31    - version 3.4.0 =
 * Feature       - Add support to pass locale to Klarna Express Checkout.
 * Fix           - Klarna Express Checkout will no longer compare the shipping address to the KEC provided address when delivery address is forced to be the billing address.

--- a/readme.txt
+++ b/readme.txt
@@ -6,8 +6,8 @@ Requires at least: 5.0
 Tested up to: 6.4.2
 Requires PHP: 7.4
 WC requires at least: 5.6.0
-WC tested up to: 8.5.0
-Stable tag: 3.3.1
+WC tested up to: 8.5.2
+Stable tag: 3.4.0
 License: GPLv3 or later
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -51,6 +51,11 @@ For help setting up and configuring Klarna Payments for WooCommerce please refer
 
 
 == Changelog ==
+= 2024.01.31    - version 3.4.0 =
+* Feature       - Add support to pass locale to Klarna Express Checkout.
+* Fix           - Klarna Express Checkout will no longer compare the shipping address to the KEC provided address when delivery address is forced to be the billing address.
+* Fix           - Fixed an issue with WooCommerce Subscriptions that would cause a recursion error when canceling a subscription with a Klarna Payments payment method.
+
 = 2024.01.16    - version 3.3.1 =
 * Fix           - Remove the required flag from the KEC client identifier setting.
 


### PR DESCRIPTION
* Fix           - Fixed an issue where the name of the previous payment gateway was set on the order after changing to, and paying with Klarna Payments.
* Fix           - Setting multiple tax rates with different priorities in WooCommerce tax settings should now work as expected.
* Fix           - Fixed an issue introduced in WooCommerce version 8.7.0 where a critical error would occur if the cart contained any coupon.