### PR TITLE
Prevent order from being processed once completed

### DIFF
--- a/classes/class-kp-callbacks.php
+++ b/classes/class-kp-callbacks.php
@@ -69,8 +69,8 @@ class KP_Callbacks {
 		$auth_token = $data['authorization_token'];
 		$country    = $order->get_billing_country();
 
-		// Dont do anything if the order has been processed.
-		if ( $order->has_status( array( 'on-hold', 'processing', 'completed' ) ) ) {
+		// Check if the PURCHASE has already been completed by the customer.
+		if ( ! empty( $order->get_date_paid() ) ) {
 			return;
 		}
 


### PR DESCRIPTION
The current control does not suffice as a cancelled order would be processed since the condition do not consider all statuses but only those that are completed.

- do not process the order again if it has already been completed by the customer.