### PR TITLE
Handle situations where billing country is unset

### DIFF
--- a/classes/class-kp-callbacks.php
+++ b/classes/class-kp-callbacks.php
@@ -67,7 +67,7 @@ class KP_Callbacks {
 		}
 
 		$auth_token = $data['authorization_token'];
-		$country    = $order->get_billing_country();
+		$country    = kp_get_klarna_country( $order );
 
 		// Dont do anything if the order has been processed.
 		if ( $order->has_status( array( 'on-hold', 'processing', 'completed' ) ) ) {

--- a/classes/requests/helpers/class-kp-order-data.php
+++ b/classes/requests/helpers/class-kp-order-data.php
@@ -251,7 +251,7 @@ class KP_Order_Data {
 			'postal_code'     => $strip_postcode_spaces ? $customer_data->get_billing_postcode() : str_replace( ' ', '', $customer_data->get_billing_postcode() ),
 			'city'            => $customer_data->get_billing_city(),
 			'region'          => $customer_data->get_billing_state(),
-			'country'         => $customer_data->get_billing_country(),
+			'country'         => empty( $customer_data->get_billing_country() ) ? kp_get_klarna_country() : $customer_data->get_billing_country(),
 		);
 
 		$shipping = array(

--- a/classes/requests/helpers/class-kp-order-data.php
+++ b/classes/requests/helpers/class-kp-order-data.php
@@ -101,7 +101,7 @@ class KP_Order_Data {
 
 		return array(
 			'purchase_country'  => $this->klarna_country,
-			'purchase_currency' => get_woocommerce_currency(),
+			'purchase_currency' => empty( $order ) ? get_woocommerce_currency() : $order->get_currency(),
 			'locale'            => kp_get_locale(),
 			'order_amount'      => $this->order_data->get_total(),
 			'order_tax_amount'  => $this->order_data->get_total_tax(),

--- a/includes/kp-functions.php
+++ b/includes/kp-functions.php
@@ -50,12 +50,20 @@ function get_klarna_customer( $customer_type ) {
  */
 function kp_get_klarna_country( $order = false ) {
 	if ( ! empty( $order ) ) {
-		return apply_filters( 'wc_klarna_payments_country', $order->get_billing_country() );
+		$country = $order->get_billing_country();
+
+		// If the billing_country field is unset, $country will be empty.
+		if ( ! empty( $country ) ) {
+			return apply_filters( 'wc_klarna_payments_country', $country );
+		}
 	}
 
-	/* The billing country selected on the checkout page is to prefer over the store's base location. It makse more sense that we check for available payment methods based on the customer's country. */
-	if ( method_exists( 'WC_Customer', 'get_billing_country' ) && ! empty( WC()->customer ) && ! empty( WC()->customer->get_billing_country() ) ) {
-		return apply_filters( 'wc_klarna_payments_country', WC()->customer->get_billing_country() );
+	/* The billing country selected on the checkout page is to prefer over the store's base location. It makes more sense that we check for available payment methods based on the customer's country. */
+	if ( method_exists( 'WC_Customer', 'get_billing_country' ) && ! empty( WC()->customer ) ) {
+		$country = WC()->customer->get_billing_country();
+		if ( ! empty( $country ) ) {
+			return apply_filters( 'wc_klarna_payments_country', $country );
+		}
 	}
 
 	/* Ignores whatever country the customer selects on the checkout page, and always uses the store's base location. Only used as fallback. */


### PR DESCRIPTION
The following changes are more in line with the way WooCommerce behave.

- in `kp_get_klarna_country`, proceed with fallback options if `get_billing_country` is empty. This should prevent 401 errors.
- retrieve the currency _directly_ from the `WC_Order` if available. This should improve compatibility with custom currency switchers.
- use `kp_get_klarna_country` in callback.

Task: https://app.clickup.com/t/86940wrwz