### PR TITLE
Version 3.5.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,9 +1,9 @@
 {
   "require": {
     "krokedil/wp-api": "^1.0",
-    "krokedil/woocommerce": "^1.5",
+    "krokedil/woocommerce": "1.6.0",
     "krokedil/klarna-express-checkout": "^1.0.0",
-    "krokedil/klarna-onsite-messaging": "^1.0.0"
+    "krokedil/klarna-onsite-messaging": "1.0.2"
   },
   "require-dev": {
     "wp-coding-standards/wpcs": "^2.3",

--- a/composer.lock
+++ b/composer.lock
@@ -143,16 +143,16 @@
         },
         {
             "name": "krokedil/klarna-onsite-messaging",
-            "version": "1.0.0",
+            "version": "1.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/krokedil/klarna-onsite-messaging.git",
-                "reference": "ec5dc4236415bd452ffaf39d70f18c0f58d42276"
+                "reference": "9046fa0efde7a4e2b0c7bb52bcfd93fd19be1ba4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/krokedil/klarna-onsite-messaging/zipball/ec5dc4236415bd452ffaf39d70f18c0f58d42276",
-                "reference": "ec5dc4236415bd452ffaf39d70f18c0f58d42276",
+                "url": "https://api.github.com/repos/krokedil/klarna-onsite-messaging/zipball/9046fa0efde7a4e2b0c7bb52bcfd93fd19be1ba4",
+                "reference": "9046fa0efde7a4e2b0c7bb52bcfd93fd19be1ba4",
                 "shasum": ""
             },
             "require": {
@@ -207,10 +207,10 @@
             ],
             "description": "Klarna On-Site Messaging for WooCommerce",
             "support": {
-                "source": "https://github.com/krokedil/klarna-onsite-messaging/tree/1.0.0",
+                "source": "https://github.com/krokedil/klarna-onsite-messaging/tree/1.0.1",
                 "issues": "https://github.com/krokedil/klarna-onsite-messaging/issues"
             },
-            "time": "2024-04-22T08:38:56+00:00"
+            "time": "2024-04-22T14:41:31+00:00"
         },
         {
             "name": "krokedil/woocommerce",
@@ -393,12 +393,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "271a13a57169a062e34a4935b5ef598bda7f7002"
+                "reference": "83f38598bafc04c9def87942775b95bfbe08880b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/271a13a57169a062e34a4935b5ef598bda7f7002",
-                "reference": "271a13a57169a062e34a4935b5ef598bda7f7002",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/83f38598bafc04c9def87942775b95bfbe08880b",
+                "reference": "83f38598bafc04c9def87942775b95bfbe08880b",
                 "shasum": ""
             },
             "require": {
@@ -466,7 +466,7 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2024-04-19T16:40:34+00:00"
+            "time": "2024-04-22T22:29:04+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "43f545a365b170959e1e5f090395b00d",
+    "content-hash": "9b8f8283269473389582f349f250c21c",
     "packages": [
         {
             "name": "firebase/php-jwt",
@@ -143,16 +143,16 @@
         },
         {
             "name": "krokedil/klarna-onsite-messaging",
-            "version": "1.0.1",
+            "version": "1.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/krokedil/klarna-onsite-messaging.git",
-                "reference": "9046fa0efde7a4e2b0c7bb52bcfd93fd19be1ba4"
+                "reference": "5f4f168d13a026f6b0da1671bcb370d6df89d7d7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/krokedil/klarna-onsite-messaging/zipball/9046fa0efde7a4e2b0c7bb52bcfd93fd19be1ba4",
-                "reference": "9046fa0efde7a4e2b0c7bb52bcfd93fd19be1ba4",
+                "url": "https://api.github.com/repos/krokedil/klarna-onsite-messaging/zipball/5f4f168d13a026f6b0da1671bcb370d6df89d7d7",
+                "reference": "5f4f168d13a026f6b0da1671bcb370d6df89d7d7",
                 "shasum": ""
             },
             "require": {
@@ -207,26 +207,27 @@
             ],
             "description": "Klarna On-Site Messaging for WooCommerce",
             "support": {
-                "source": "https://github.com/krokedil/klarna-onsite-messaging/tree/1.0.1",
+                "source": "https://github.com/krokedil/klarna-onsite-messaging/tree/1.0.2",
                 "issues": "https://github.com/krokedil/klarna-onsite-messaging/issues"
             },
-            "time": "2024-04-22T14:41:31+00:00"
+            "time": "2024-05-13T08:40:49+00:00"
         },
         {
             "name": "krokedil/woocommerce",
-            "version": "1.5.0",
+            "version": "1.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/krokedil/woocommerce.git",
-                "reference": "0f92aa008d8af7236094dc52497af7ae62f53937"
+                "reference": "7aefe4d3177dfea4a711095ac25bbdc629f29d51"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/krokedil/woocommerce/zipball/0f92aa008d8af7236094dc52497af7ae62f53937",
-                "reference": "0f92aa008d8af7236094dc52497af7ae62f53937",
+                "url": "https://api.github.com/repos/krokedil/woocommerce/zipball/7aefe4d3177dfea4a711095ac25bbdc629f29d51",
+                "reference": "7aefe4d3177dfea4a711095ac25bbdc629f29d51",
                 "shasum": ""
             },
             "require-dev": {
+                "10up/wp_mock": "^1.0",
                 "php": "~7.1 || ~8.0",
                 "php-stubs/woocommerce-stubs": "^7.2",
                 "php-stubs/wordpress-stubs": "^6.1"
@@ -235,6 +236,11 @@
             "autoload": {
                 "psr-4": {
                     "Krokedil\\WooCommerce\\": "src/"
+                }
+            },
+            "autoload-dev": {
+                "psr-4": {
+                    "Krokedil\\WooCommerce\\Tests\\": "tests/"
                 }
             },
             "license": [
@@ -248,10 +254,10 @@
             ],
             "description": "A library package for Krokedils plugins that contains helper methods when working with WooCommerce.",
             "support": {
-                "source": "https://github.com/krokedil/woocommerce/tree/1.5.0",
+                "source": "https://github.com/krokedil/woocommerce/tree/1.6.0",
                 "issues": "https://github.com/krokedil/woocommerce/issues"
             },
-            "time": "2024-03-12T13:13:23+00:00"
+            "time": "2024-05-13T08:14:44+00:00"
         },
         {
             "name": "krokedil/wp-api",
@@ -342,16 +348,16 @@
         },
         {
             "name": "php-stubs/wordpress-stubs",
-            "version": "v6.5.2",
+            "version": "v6.5.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-stubs/wordpress-stubs.git",
-                "reference": "379f17a90c01498d4c99a0d15aab6e7aa6a2c840"
+                "reference": "e611a83292d02055a25f83291a98fadd0c21e092"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/379f17a90c01498d4c99a0d15aab6e7aa6a2c840",
-                "reference": "379f17a90c01498d4c99a0d15aab6e7aa6a2c840",
+                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/e611a83292d02055a25f83291a98fadd0c21e092",
+                "reference": "e611a83292d02055a25f83291a98fadd0c21e092",
                 "shasum": ""
             },
             "require-dev": {
@@ -383,9 +389,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-stubs/wordpress-stubs/issues",
-                "source": "https://github.com/php-stubs/wordpress-stubs/tree/v6.5.2"
+                "source": "https://github.com/php-stubs/wordpress-stubs/tree/v6.5.3"
             },
-            "time": "2024-04-14T17:30:14+00:00"
+            "time": "2024-05-08T02:12:31+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
@@ -393,12 +399,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "83f38598bafc04c9def87942775b95bfbe08880b"
+                "reference": "4fd52f75c8f29114423e9a379bf86fa894750bc3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/83f38598bafc04c9def87942775b95bfbe08880b",
-                "reference": "83f38598bafc04c9def87942775b95bfbe08880b",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/4fd52f75c8f29114423e9a379bf86fa894750bc3",
+                "reference": "4fd52f75c8f29114423e9a379bf86fa894750bc3",
                 "shasum": ""
             },
             "require": {
@@ -466,7 +472,7 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2024-04-22T22:29:04+00:00"
+            "time": "2024-05-06T04:13:19+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",

--- a/klarna-payments-for-woocommerce.php
+++ b/klarna-payments-for-woocommerce.php
@@ -10,7 +10,7 @@
  * Domain Path: /languages
  *
  * WC requires at least: 5.6.0
- * WC tested up to: 8.8.2
+ * WC tested up to: 8.9.0
  *
  * Copyright (c) 2017-2024 Krokedil
  *

--- a/klarna-payments-for-woocommerce.php
+++ b/klarna-payments-for-woocommerce.php
@@ -5,7 +5,7 @@
  * Description: Provides Klarna Payments as payment method to WooCommerce.
  * Author: klarna
  * Author URI: https://www.klarna.com/
- * Version: 3.5.1
+ * Version: 3.5.2
  * Text Domain: klarna-payments-for-woocommerce
  * Domain Path: /languages
  *
@@ -40,7 +40,7 @@ use Krokedil\KlarnaOnsiteMessaging\KlarnaOnsiteMessaging;
 /**
  * Required minimums and constants
  */
-define( 'WC_KLARNA_PAYMENTS_VERSION', '3.5.1' );
+define( 'WC_KLARNA_PAYMENTS_VERSION', '3.5.2' );
 define( 'WC_KLARNA_PAYMENTS_MIN_PHP_VER', '7.4.0' );
 define( 'WC_KLARNA_PAYMENTS_MIN_WC_VER', '5.6.0' );
 define( 'WC_KLARNA_PAYMENTS_MAIN_FILE', __FILE__ );

--- a/klarna-payments-for-woocommerce.php
+++ b/klarna-payments-for-woocommerce.php
@@ -5,7 +5,7 @@
  * Description: Provides Klarna Payments as payment method to WooCommerce.
  * Author: klarna
  * Author URI: https://www.klarna.com/
- * Version: 3.5.2
+ * Version: 3.5.3
  * Text Domain: klarna-payments-for-woocommerce
  * Domain Path: /languages
  *
@@ -40,7 +40,7 @@ use Krokedil\KlarnaOnsiteMessaging\KlarnaOnsiteMessaging;
 /**
  * Required minimums and constants
  */
-define( 'WC_KLARNA_PAYMENTS_VERSION', '3.5.2' );
+define( 'WC_KLARNA_PAYMENTS_VERSION', '3.5.3' );
 define( 'WC_KLARNA_PAYMENTS_MIN_PHP_VER', '7.4.0' );
 define( 'WC_KLARNA_PAYMENTS_MIN_WC_VER', '5.6.0' );
 define( 'WC_KLARNA_PAYMENTS_MAIN_FILE', __FILE__ );

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "klarna-payments-for-woocommerce",
-  "version": "3.4.2",
+  "version": "3.5.3",
   "description": "Klarna Payments for WooCommerce",
   "main": "gulpfile.js",
   "repository": "https://github.com/krokedil/klarna-payments-for-woocommerce.git",

--- a/readme.txt
+++ b/readme.txt
@@ -3,10 +3,10 @@ Contributors: klarna, krokedil, automattic
 Tags: woocommerce, klarna, ecommerce, e-commerce
 Donate link: https://klarna.com
 Requires at least: 5.0
-Tested up to: 6.5.2
+Tested up to: 6.5.3
 Requires PHP: 7.4
 WC requires at least: 5.6.0
-WC tested up to: 8.8.2
+WC tested up to: 8.9.0
 Stable tag: 3.5.2
 License: GPLv3 or later
 License URI: http://www.gnu.org/licenses/gpl-3.0.html

--- a/readme.txt
+++ b/readme.txt
@@ -7,7 +7,7 @@ Tested up to: 6.5.3
 Requires PHP: 7.4
 WC requires at least: 5.6.0
 WC tested up to: 8.9.0
-Stable tag: 3.5.2
+Stable tag: 3.5.3
 License: GPLv3 or later
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -51,6 +51,14 @@ For help setting up and configuring Klarna Payments for WooCommerce please refer
 
 
 == Changelog ==
+= 2024.05.13    - version 3.5.3 =
+* Fix           - [KOSM] Restored the theme setting "custom" (previously known as "none").
+* Fix           - [KOSM] Resolved deprecation warning in PHP 8.2.
+* Fix           - [KOSM] The disable KOSM admin banner will now only show if the KOSM plugin is enabled (previously it would always show as long as the KOSM plugin is installed).
+* Fix           - [KOSM] The shortcode should now work as intended on non-shop pages.
+* Tweak         - Enhanced compatibility with third-party gift card and coupon plugins.
+* Tweak         - The "Klarna order id" label will now only be added to the email template if the Klarna order ID is set.
+
 = 2024.04.23    - version 3.5.2 =
 * Fix           - Update package version.
 

--- a/readme.txt
+++ b/readme.txt
@@ -7,7 +7,7 @@ Tested up to: 6.5.2
 Requires PHP: 7.4
 WC requires at least: 5.6.0
 WC tested up to: 8.8.2
-Stable tag: 3.5.1
+Stable tag: 3.5.2
 License: GPLv3 or later
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -51,6 +51,9 @@ For help setting up and configuring Klarna Payments for WooCommerce please refer
 
 
 == Changelog ==
+= 2024.04.23    - version 3.5.2 =
+* Fix           - Update package version.
+
 = 2024.04.22    - version 3.5.1 =
 * Fix           - Fixed a critical error that happened under certain conditions if the KOSM plugin is active. 
 


### PR DESCRIPTION
* Fix           - [KOSM] Restored the theme setting "custom" (previously known as "none").
* Fix           - [KOSM] Resolved deprecation warning in PHP 8.2.
* Fix           - [KOSM] The disable KOSM admin banner will now only show if the KOSM plugin is enabled (previously it would always show as long as the KOSM plugin is installed).
* Fix           - [KOSM] The shortcode should now work as intended on non-shop pages.
* Tweak         - Enhanced compatibility with third-party gift card and coupon plugins.
* Tweak         - The "Klarna order id" label will now only be added to the email template if the Klarna order ID is set.