### PR TITLE
autcomplete=off is ignored, use webauthn

### DIFF
--- a/classes/admin/class-kp-form-fields.php
+++ b/classes/admin/class-kp-form-fields.php
@@ -179,7 +179,7 @@ class KP_Form_Fields {
 			'default'           => '',
 			'desc_tip'          => false,
 			'custom_attributes' => array(
-				'autocomplete' => 'off',
+				'autocomplete' => 'webauthn',
 			),
 		);
 	}
@@ -259,7 +259,6 @@ class KP_Form_Fields {
 		$section[ 'test_shared_secret_' . $country_code ] = self::kp_form_test_password();
 
 		return $section;
-
 	}
 
 	/**

--- a/classes/admin/class-kp-form-fields.php
+++ b/classes/admin/class-kp-form-fields.php
@@ -179,7 +179,7 @@ class KP_Form_Fields {
 			'default'           => '',
 			'desc_tip'          => false,
 			'custom_attributes' => array(
-				'autocomplete' => 'webauthn',
+				'autocomplete' => 'off',
 			),
 		);
 	}
@@ -197,7 +197,7 @@ class KP_Form_Fields {
 			'default'           => '',
 			'desc_tip'          => false,
 			'custom_attributes' => array(
-				'autocomplete' => 'off',
+				'autocomplete' => 'off new-password',
 			),
 		);
 	}


### PR DESCRIPTION
Chrome has decided to ignore autocomplete=off, and similarly so has Safari (see notes https://caniuse.com/input-autocomplete-onoff).

One workaround is to use either `one-time-code` or `webauthn`. I have opted to chose `webauthn` since I've experienced issues with password managers that keep displaying the one-time code autofill pop-up. To ensure this doesn't happen for WebAuthn, I set up "WP-WebAuthn" by Axton, and verified that it doesn't pop-up on the KP settings.

Tested on Chrome 100 (Windows 10), 127 (Linux),  Firefox 128 (Linux) and Safari 14 (MacOS Big Sur).

---

Other options such as "__away" (suggested in SO) or other invalid value doesn't work. Similarly, valid values such as "url" and "photo" don't work either.

https://app.clickup.com/t/86940we4y