### PR TITLE
Add support for Linear Checkout by Cartimize

### DIFF
--- a/includes/kp-functions.php
+++ b/includes/kp-functions.php
@@ -200,10 +200,8 @@ function kp_print_error_message( $wp_error ) {
 		if ( function_exists( 'wc_add_notice' ) ) {
 			wc_add_notice( $error_message, 'error' );
 		}
-	} else {
-		if ( function_exists( 'wc_print_notice' ) ) {
+	} elseif ( function_exists( 'wc_print_notice' ) ) {
 			wc_print_notice( $error_message, 'error' );
-		}
 	}
 }
 

--- a/templates/klarna-payments-categories.php
+++ b/templates/klarna-payments-categories.php
@@ -39,6 +39,9 @@ if ( is_array( $payment_categories ) ) {
 			}
 		}
 
-		wc_get_template( 'checkout/payment-method.php', array( 'gateway' => $kp ) );
+		// For "Linear Checkout for WooCommerce by Cartimize" to work, we cannot output any HTML.
+		if ( did_action( 'cartimize_get_payment_methods_html' ) === 0 ) {
+			wc_get_template( 'checkout/payment-method.php', array( 'gateway' => $kp ) );
+		}
 	}
 }


### PR DESCRIPTION
When Cartimize retrieve the payment methods, they replace the checkout template which results in `override_kp_payment_option` not being executed, and thus not populating the KP payment method. To make Linear Checkout work, we need hook onto the `cartimize_get_payment_methods_html` to perform this work.

```php
add_action(
	'cartimize_get_payment_methods_html',
	function () {
		include_once WC_KLARNA_PAYMENTS_PLUGIN_PATH . '/templates/klarna-payments-categories.php';
	}
);
```

However, this will not suffice, since `cartimize_get_payment_methods_html` will stop working if we render any HTML content. For this reason, we cannot call the `wc_get_template`.

https://app.clickup.com/t/8692yh4fy