### PR TITLE
Check accepted terms before pay for order

### DIFF
--- a/assets/js/klarna-payments.js
+++ b/assets/js/klarna-payments.js
@@ -243,6 +243,14 @@ jQuery(function ($) {
 			return false;
 		},
 
+		isTermsAccepted: function () {
+			if($('#terms').is(':checked')) {
+				return true;
+			}
+
+			return false;
+		},
+
 		setRadioButtonValues: function () {
 			$('input[name="payment_method"]').each(function () {
 				if ($(this).val().indexOf("klarna_payments") !== -1) {
@@ -500,8 +508,9 @@ jQuery(function ($) {
 		},
 
 		klarnaPayForOrder: function (event) {
-			if (klarna_payments.isKlarnaPaymentsSelected()) {
+			if (klarna_payments.isKlarnaPaymentsSelected() && klarna_payments.isTermsAccepted()) {
 				event.preventDefault();
+
 				klarna_payments.addresses = klarna_payments_params.addresses;
 				klarna_payments.authorizeKlarnaOrder(
 					klarna_payments_params.order_id,
@@ -556,6 +565,7 @@ jQuery(function ($) {
 							}
 						} catch (err) {
 							if (data.messages) {
+								alert("Failed with messages");
 								klarna_payments.logToFile(
 									"Checkout error | " + data.messages
 								);
@@ -600,6 +610,8 @@ jQuery(function ($) {
 		 * @param {string} event
 		 */
 		failOrder: function (event, error_message) {
+			alert(error_message);
+			console.log(error_message);
 			// Re-enable the form.
 			$("body").trigger("updated_checkout");
 			$("form.checkout").removeClass("processing");

--- a/classes/class-kp-assets.php
+++ b/classes/class-kp-assets.php
@@ -111,6 +111,7 @@ class KP_Assets {
 			// i18n.
 			'i18n'                   => array(
 				'order_button_label' => apply_filters( 'kp_blocks_order_button_label', __( 'Pay with Klarna', 'klarna-payments-for-woocommerce' ) ),
+				'terms_not_checked'  => __( 'Please read and accept the terms and conditions to proceed with your order.', 'woocommerce' ),
 			),
 		);
 


### PR DESCRIPTION
**Question:**

Should I instead build onto isTermsAccepted to make an AJAX call where I make a PHP check like this:

```
if ( ! empty( $_POST['terms-field'] ) && empty( $_POST['terms'] ) ) {
                    wc_add_notice( __( 'Please read and accept the terms and conditions to proceed with your order.', 'woocommerce' ), 'error' );
                    return;
}
```
                
And finally show the return message with the `failOrder` function in JS?

Or is this overkill/solved in a better way? :)