### PR TITLE
Fail the order where applicable

### DIFF
--- a/classes/class-kp-ajax.php
+++ b/classes/class-kp-ajax.php
@@ -92,8 +92,8 @@ if ( ! class_exists( 'KP_AJAX' ) ) {
 			}
 
 			$response = KP_WC()->api->place_order( kp_get_klarna_country( $order ), $auth_token, $order_id );
-
 			if ( is_wp_error( $response ) ) {
+				$order->update_status( 'failed', __( 'Failed to create the Klarna order.', 'klarna-payments-for-woocommerce' ) );
 				wp_send_json_error( kp_extract_error_message( $response ) );
 			}
 
@@ -153,11 +153,13 @@ if ( ! class_exists( 'KP_AJAX' ) ) {
 				wp_send_json_error( 'unexpected form data' );
 			}
 
-			$show_form = 'true' === $show_form ? true : false;
+			// Indicates whether Klarna payments is available.
+			$show_form = wc_string_to_bool( $show_form );
 			if ( $show_form ) {
 				$order->add_order_note( __( 'Customer aborted purchase with Klarna.', 'klarna-payments-for-woocommerce' ) );
 			} else {
-				$order->add_order_note( __( 'Authorization rejected by Klarna.', 'klarna-payments-for-woocommerce' ) );
+				$order->update_status( 'failed', __( 'Authorization rejected by Klarna.', 'klarna-payments-for-woocommerce' ) );
+				$order->save();
 			}
 
 			wp_send_json_success();

--- a/classes/class-kp-ajax.php
+++ b/classes/class-kp-ajax.php
@@ -93,7 +93,8 @@ if ( ! class_exists( 'KP_AJAX' ) ) {
 
 			$response = KP_WC()->api->place_order( kp_get_klarna_country( $order ), $auth_token, $order_id );
 			if ( is_wp_error( $response ) ) {
-				$order->update_status( 'failed', __( 'Failed to create the Klarna order.', 'klarna-payments-for-woocommerce' ) );
+				$status = apply_filters( 'kp_create_order_failed', 'on-hold' );
+				$order->update_status( $status, __( 'Failed to create the Klarna order.', 'klarna-payments-for-woocommerce' ) );
 				wp_send_json_error( kp_extract_error_message( $response ) );
 			}
 
@@ -158,7 +159,8 @@ if ( ! class_exists( 'KP_AJAX' ) ) {
 			if ( $show_form ) {
 				$order->add_order_note( __( 'Customer aborted purchase with Klarna.', 'klarna-payments-for-woocommerce' ) );
 			} else {
-				$order->update_status( 'failed', __( 'Authorization rejected by Klarna.', 'klarna-payments-for-woocommerce' ) );
+				$status = apply_filters( 'kp_authorization_rejected', 'on-hold' );
+				$order->update_status( $status, __( 'Authorization rejected by Klarna.', 'klarna-payments-for-woocommerce' ) );
 				$order->save();
 			}
 

--- a/includes/kp-functions.php
+++ b/includes/kp-functions.php
@@ -170,7 +170,8 @@ function kp_process_pending( $order, $decoded ) {
  * @return array   $result  Payment result.
  */
 function kp_process_rejected( $order, $decoded ) {
-	$order->update_status( 'failed', __( 'Klarna order was rejected.', 'klarna-payments-for-woocommerce' ) );
+	$status = apply_filters( 'kp_authorization_rejected', 'on-hold' );
+	$order->update_status( $status, __( 'Klarna order was rejected.', 'klarna-payments-for-woocommerce' ) );
 	do_action( 'wc_klarna_payments_rejected', $order->get_id(), $decoded );
 	do_action( 'wc_klarna_rejected', $order->get_id(), $decoded );
 	return array(

--- a/includes/kp-functions.php
+++ b/includes/kp-functions.php
@@ -170,7 +170,7 @@ function kp_process_pending( $order, $decoded ) {
  * @return array   $result  Payment result.
  */
 function kp_process_rejected( $order, $decoded ) {
-	$order->update_status( 'on-hold', 'Klarna order was rejected.' );
+	$order->update_status( 'failed', __( 'Klarna order was rejected.', 'klarna-payments-for-woocommerce' ) );
 	do_action( 'wc_klarna_payments_rejected', $order->get_id(), $decoded );
 	do_action( 'wc_klarna_rejected', $order->get_id(), $decoded );
 	return array(


### PR DESCRIPTION
Currently, if the authorization fails, we just write an order note about it.

- set the order status to "failed" where applicable.

https://app.clickup.com/t/8696hvdw6