### PR TITLE
Settings active/not active badge

### DIFF
--- a/assets/css/klarna-payments-admin.css
+++ b/assets/css/klarna-payments-admin.css
@@ -400,3 +400,19 @@ div.kp_settings__section_content .kp_settings__content_gradient {
 	padding: 0 4px;
 	opacity: 1;
 }
+
+.kp_settings__mode_badge {
+	background-color: #e3e5e9;
+	border: solid 1px #1d2327;
+	color: #1d2327;
+	border-radius: 20px;
+	padding: 5px 10px;
+	font-size: 12px;
+	font-weight: 700;
+}
+
+.kp_settings__mode_badge.active {
+	background-color: #92ffaf;
+	border-color: #92ffaf;
+}
+

--- a/classes/admin/class-kp-settings-page.php
+++ b/classes/admin/class-kp-settings-page.php
@@ -107,7 +107,7 @@ class KP_Settings_Page {
 			foreach ( $settings_keys as $setting_key ) {
 				if ( isset( $settings[ $setting_key ] ) && 'yes' === $settings[ $setting_key ] ) {
 					$feature_status = array(
-						'class' => 'active',
+						'class' => ' active',
 						'title' => __( 'Active', 'klarna-payments-for-woocommerce' ),
 					);
 					break;
@@ -124,7 +124,7 @@ class KP_Settings_Page {
 					<?php
 					if ( $feature_status ) {
 						?>
-						<span class="kp_settings__mode_badge <?php echo esc_attr( $feature_status['class'] ); ?>"><?php echo esc_html( $feature_status['title'] ); ?> </span>
+						<span class="kp_settings__mode_badge<?php echo esc_attr( $feature_status['class'] ); ?>"><?php echo esc_html( $feature_status['title'] ); ?> </span>
 						<?php
 					}
 					?>


### PR DESCRIPTION
Adds an Active/Not active badge to each feature section on the settings page.

Question 1: Right now, the general enabled settings for the different features follow different naming conventions (Also at the moment OSM does not have this setting, but a PR is created for this). I added some weird mapping to this PR, but perhaps we could rename the setting or give them some other identifier, to check this in a more neat way?


Question 2: I decided on not to update the badge with JS,  on change of the setting checkbox. My reasoning is that the badge signal the actual saved value, so it should only be updated when the page is saved. Perhaps that is confusing to the user? Could of course add a JS update of the badge.