### PR TITLE
Add kp_modal_action

### DIFF
--- a/assets/js/klarna-express-button.js
+++ b/assets/js/klarna-express-button.js
@@ -1,44 +1,42 @@
+jQuery( function ( $ ) {
+	"use strict"
 
-jQuery(function ($) {
-	'use strict';
-
-	if (klarna_payments_express_button_params === undefined) {
-		return false;
+	if ( klarna_payments_express_button_params === undefined ) {
+		return false
 	}
 
-	/* 
-	* If you reload the page or when the mini-cart is updated, the klarna-placement-button might disappear. 
-	* In this case, we have to force re-paint the button. This is most likely happening because the window object
-	* uses cached data instead of dynamically refetching the klarna-express-button.
-	*/
-	$(document.body).on('updated_cart_totals added_to_cart removed_from_cart', function () {
-		Klarna.ExpressButton.refreshButtons();
-	});
+	/*
+	 * If you reload the page or when the mini-cart is updated, the klarna-placement-button might disappear.
+	 * In this case, we have to force re-paint the button. This is most likely happening because the window object
+	 * uses cached data instead of dynamically refetching the klarna-express-button.
+	 */
+	$( document.body ).on( "updated_cart_totals added_to_cart removed_from_cart", function () {
+		Klarna.ExpressButton.refreshButtons()
+	} )
 
 	window.klarnaExpressButtonAsyncCallback = function () {
-		Klarna.ExpressButton.refreshButtons();
+		Klarna.ExpressButton.refreshButtons()
 
-		Klarna.ExpressButton.on('user-authenticated', function (callbackData) {
-			console.log('Klarna Express Button', callbackData);
-			$.ajax({
-				type: 'POST',
+		Klarna.ExpressButton.on( "user-authenticated", function ( callbackData ) {
+			console.log( "Klarna Express Button", callbackData )
+			$.ajax( {
+				type: "POST",
 				data: {
 					message: callbackData,
 					nonce: klarna_payments_express_button_params.express_button_nonce,
 				},
-				dataType: 'JSON',
+				dataType: "JSON",
 				url: klarna_payments_express_button_params.express_button_url,
-				success: function (response) {
-					console.log('[SUCCESS] Express Button.');
+				success: function ( response ) {
+					console.log( "[SUCCESS] Express Button." )
 					/* The data is the URL for the checkout page. */
-					window.location.href = response['data'];
+					window.location.href = response[ "data" ]
 				},
-				error: function (response) {
+				error: function ( response ) {
 					/* The data is an error message. */
-					console.warn('[ERROR] Express Button: ', response['data']);
-				}
-			});
-		});
+					console.warn( "[ERROR] Express Button: ", response[ "data" ] )
+				},
+			} )
+		} )
 	}
-});
-
+} )

--- a/assets/js/klarna-for-woocommerce-addons.js
+++ b/assets/js/klarna-for-woocommerce-addons.js
@@ -1,29 +1,29 @@
-jQuery( function($) {
-	'use strict';
-	$('.checkout-addon-action .button').click(function(){
-		var pluginStatus = $(this).attr('data-status');
-		var pluginAction = $(this).attr('data-action');
-		var pluginId = $(this).attr('data-plugin-id');
-		var pluginSlug = $(this).attr('data-plugin-slug');
-		var pluginUrl = $(this).attr('data-plugin-url');
-		var disabledStatus = $(this).hasClass('disabled');
-		console.log('status start');
-		console.log(pluginStatus);
-		console.log(pluginAction);
-		console.log(pluginSlug);
-		
+jQuery( function ( $ ) {
+	"use strict"
+	$( ".checkout-addon-action .button" ).click( function () {
+		var pluginStatus = $( this ).attr( "data-status" )
+		var pluginAction = $( this ).attr( "data-action" )
+		var pluginId = $( this ).attr( "data-plugin-id" )
+		var pluginSlug = $( this ).attr( "data-plugin-slug" )
+		var pluginUrl = $( this ).attr( "data-plugin-url" )
+		var disabledStatus = $( this ).hasClass( "disabled" )
+		console.log( "status start" )
+		console.log( pluginStatus )
+		console.log( pluginAction )
+		console.log( pluginSlug )
+
 		// Abort function if current user can't activate plugins.
-		if( true === disabledStatus ) {
-			return;
+		if ( true === disabledStatus ) {
+			return
 		}
-		$(this).attr('disabled','disabled');
-		$(this).children().attr('disabled','disabled');
-		var button = this;
-		$.ajax({
-			type: 'POST',
+		$( this ).attr( "disabled", "disabled" )
+		$( this ).children().attr( "disabled", "disabled" )
+		var button = this
+		$.ajax( {
+			type: "POST",
 			url: ajaxurl,
 			data: {
-				action: 'change_klarna_addon_status',
+				action: "change_klarna_addon_status",
 				nonce: kp_addons_params.change_addon_status_nonce,
 				plugin_status: pluginStatus,
 				plugin_action: pluginAction,
@@ -31,37 +31,47 @@ jQuery( function($) {
 				plugin_slug: pluginSlug,
 				plugin_url: pluginUrl,
 			},
-			dataType: 'json',
-			success: function(data) {
-				console.log('success');
-				console.log(data);
+			dataType: "json",
+			success: function ( data ) {
+				console.log( "success" )
+				console.log( data )
 			},
-			error: function(data) {
-				console.log('error');
-				console.log(data);
+			error: function ( data ) {
+				console.log( "error" )
+				console.log( data )
 			},
-			complete: function(data) {
-				
-				console.log('complete');
-				console.log(data);
-				if( true === data.responseJSON.success ) {
+			complete: function ( data ) {
+				console.log( "complete" )
+				console.log( data )
+				if ( true === data.responseJSON.success ) {
 					// Change the status.
-					$( '.checkout-addon.' + pluginId + ' .button' ).attr('data-status', data.responseJSON.data.new_status );
-					$( '.checkout-addon.' + pluginId + ' .button' ).attr('data-action', data.responseJSON.data.new_action );
-					$( '.checkout-addon.' + pluginId + ' .button .action-text').text( data.responseJSON.data.new_status_label );
+					$( ".checkout-addon." + pluginId + " .button" ).attr(
+						"data-status",
+						data.responseJSON.data.new_status,
+					)
+					$( ".checkout-addon." + pluginId + " .button" ).attr(
+						"data-action",
+						data.responseJSON.data.new_action,
+					)
+					$( ".checkout-addon." + pluginId + " .button .action-text" ).text(
+						data.responseJSON.data.new_status_label,
+					)
 
-					if( 'installed' === data.responseJSON.data.new_status ) {
-						$( '.checkout-addon.' + pluginId + ' .button .switch' ).removeClass('download');
-						$( '.checkout-addon.' + pluginId + ' .button .switch .round' ).removeClass('dashicons').removeClass('dashicons-download').addClass('slider');
+					if ( "installed" === data.responseJSON.data.new_status ) {
+						$( ".checkout-addon." + pluginId + " .button .switch" ).removeClass( "download" )
+						$( ".checkout-addon." + pluginId + " .button .switch .round" )
+							.removeClass( "dashicons" )
+							.removeClass( "dashicons-download" )
+							.addClass( "slider" )
 					}
 				} else {
-					$( '.checkout-addon.' + pluginId ).append( '<p class="addon-error">' + data.responseJSON.data + '</p>' );
+					$( ".checkout-addon." + pluginId ).append(
+						'<p class="addon-error">' + data.responseJSON.data + "</p>",
+					)
 				}
-				$(button).removeAttr('disabled');
-				$(button).children().removeAttr('disabled');
-			}
-		});
-						
-	});
-
-});
+				$( button ).removeAttr( "disabled" )
+				$( button ).children().removeAttr( "disabled" )
+			},
+		} )
+	} )
+} )

--- a/assets/js/klarna-payments-admin.js
+++ b/assets/js/klarna-payments-admin.js
@@ -1,5 +1,5 @@
-jQuery(function ($) {
-	'use strict';
+jQuery( function ( $ ) {
+	"use strict"
 	const kp_admin = {
 		openedIcon: "dashicons-arrow-up-alt2",
 		closedIcon: "dashicons-arrow-down-alt2",
@@ -8,214 +8,192 @@ jQuery(function ($) {
 		toggleEuSelector: "#woocommerce_klarna_payments_combine_eu_credentials",
 
 		init: function () {
-			$(document).on(
-				"click",
-				".kp_settings__fields_toggle",
-				this.toggleCredentials
-			);
+			$( document ).on( "click", ".kp_settings__fields_toggle", this.toggleCredentials )
 
-			$(document).on(
-				"click",
-				".kp_settings__section_toggle",
-				this.toggleSection
-			);
+			$( document ).on( "click", ".kp_settings__section_toggle", this.toggleSection )
 
-			$(document).on(
-				"change",
-				this.toggleTestModeSelector,
-				this.toggleTest
-			);
+			$( document ).on( "change", this.toggleTestModeSelector, this.toggleTest )
 
-			$(document).on(
+			$( document ).on(
 				"change",
 				"#woocommerce_klarna_payments_kec_theme, #woocommerce_klarna_payments_kec_shape",
-				this.changeKecPreview
-			);
+				this.changeKecPreview,
+			)
 
-			$(document).on(
+			$( document ).on(
 				"change",
 				"#woocommerce_klarna_payments_placement_data_key_product, #woocommerce_klarna_payments_onsite_messaging_theme_product, #woocommerce_klarna_payments_placement_data_key_cart, #woocommerce_klarna_payments_onsite_messaging_theme_cart",
-				this.changeOsmPreview
-			);
+				this.changeOsmPreview,
+			)
 
-			$(document).on("change", this.toggleEuSelector, this.toggleEu);
+			$( document ).on( "change", this.toggleEuSelector, this.toggleEu )
 
 			// Trigger the change event to set the initial state.
-			$(this.toggleTestModeSelector).trigger("change");
+			$( this.toggleTestModeSelector ).trigger( "change" )
 
 			// Update all previews on page load.
-			this.updatePreviews();
+			this.updatePreviews()
 
-			$(document).on(
-				"click", 
+			$( document ).on(
+				"click",
 				"#woocommerce_klarna_payments_available_countries + .select2",
-				this.addSelectAllCountries
-			);
+				this.addSelectAllCountries,
+			)
 
-			$(document).on(
-				"click", 
+			$( document ).on( "click", "#klarna_payments_select_all_countries", this.toggleSelectAll )
+
+			$( document ).on(
+				"mouseover",
 				"#klarna_payments_select_all_countries",
-				this.toggleSelectAll
-			);
-		
-			$(document).on(
-				"mouseover", 
-				"#klarna_payments_select_all_countries",
-				$('.select2-results__option').removeClass('select2-results__option--highlighted')
-			);
-		
+				$( ".select2-results__option" ).removeClass( "select2-results__option--highlighted" ),
+			)
 		},
 
-		toggleCredentials: function (e) {
-			e.preventDefault();
-			const $this = $(this);
-			const $td = $this.parent().parent().find("td");
+		toggleCredentials: function ( e ) {
+			e.preventDefault()
+			const $this = $( this )
+			const $td = $this.parent().parent().find( "td" )
 
 			// Toggle the kp_settings__credentials_field kp_settings__credentials_field_hidden class
-			$td.toggleClass("kp_settings__credentials_field_hidden");
+			$td.toggleClass( "kp_settings__credentials_field_hidden" )
 
 			// Toggle the icon
-			$this
-				.find("span")
-				.toggleClass(kp_admin.openedIcon)
-				.toggleClass(kp_admin.closedIcon);
+			$this.find( "span" ).toggleClass( kp_admin.openedIcon ).toggleClass( kp_admin.closedIcon )
 		},
 
-		toggleSection: function (e) {
-			e.preventDefault();
-			const $this = $(this);
-			const $section = $this.closest(".kp_settings__section");
+		toggleSection: function ( e ) {
+			e.preventDefault()
+			const $this = $( this )
+			const $section = $this.closest( ".kp_settings__section" )
 			// Get all the children of the section that is the toggle button.
-			const $toggle = $section.find(".kp_settings__section_toggle");
-			const $gradient = $section.find(".kp_settings__content_gradient");
+			const $toggle = $section.find( ".kp_settings__section_toggle" )
+			const $gradient = $section.find( ".kp_settings__content_gradient" )
 
-			$section.find("table").toggleClass("kp_settings__section_content_hidden");
-			$section.find(".kp_settings__section_previews").toggleClass("kp_settings__section_content_hidden");
-			$gradient.toggle();
+			$section.find( "table" ).toggleClass( "kp_settings__section_content_hidden" )
+			$section.find( ".kp_settings__section_previews" ).toggleClass( "kp_settings__section_content_hidden" )
+			$gradient.toggle()
 
 			// Toggle the icon
-			$toggle
-				.toggleClass(kp_admin.openedIcon)
-				.toggleClass(kp_admin.closedIcon);
+			$toggle.toggleClass( kp_admin.openedIcon ).toggleClass( kp_admin.closedIcon )
 		},
 
 		toggleEu: function () {
-			const eu = $(kp_admin.toggleEuSelector).is(":checked");
+			const eu = $( kp_admin.toggleEuSelector ).is( ":checked" )
 
-			const $wrappers = $(".kp_settings__credentials");
-			const $euRegion = $wrappers.filter("[data-eu-region]");
-			const $euCountry = $wrappers.filter("[data-eu-country]");
+			const $wrappers = $( ".kp_settings__credentials" )
+			const $euRegion = $wrappers.filter( "[data-eu-region]" )
+			const $euCountry = $wrappers.filter( "[data-eu-country]" )
 
-			if (eu) {
-				$euRegion.show();
-				$euCountry.hide();
+			if ( eu ) {
+				$euRegion.show()
+				$euCountry.hide()
 			} else {
-				$euRegion.hide();
-				$euCountry.show();
+				$euRegion.hide()
+				$euCountry.show()
 			}
 		},
 
 		toggleTest: function () {
-			const test = $(kp_admin.toggleTestModeSelector).is(":checked");
+			const test = $( kp_admin.toggleTestModeSelector ).is( ":checked" )
 
-			const $wrappers = $(".kp_settings__credentials");
-			const $prod = $wrappers.find(
-				".kp_settings__production_credentials"
-			);
-			const $test = $wrappers.find(".kp_settings__test_credentials");
+			const $wrappers = $( ".kp_settings__credentials" )
+			const $prod = $wrappers.find( ".kp_settings__production_credentials" )
+			const $test = $wrappers.find( ".kp_settings__test_credentials" )
 
-			if (test) {
-				$prod.hide();
-				$test.show();
+			if ( test ) {
+				$prod.hide()
+				$test.show()
 			} else {
-				$prod.show();
-				$test.hide();
+				$prod.show()
+				$test.hide()
 			}
 		},
 
 		changeKecPreview: function () {
-			let theme = $("#woocommerce_klarna_payments_kec_theme").val();
-			let shape = $("#woocommerce_klarna_payments_kec_shape").val();
+			let theme = $( "#woocommerce_klarna_payments_kec_theme" ).val()
+			let shape = $( "#woocommerce_klarna_payments_kec_shape" ).val()
 
-			if( '' === theme || 'default' === theme ) {
-				theme = 'dark';
+			if ( "" === theme || "default" === theme ) {
+				theme = "dark"
 			}
 
-			const $img = $(
-				"#klarna-payments-settings-kec_settings .kp_settings__section_previews img"
-			);
+			const $img = $( "#klarna-payments-settings-kec_settings .kp_settings__section_previews img" )
 
-			const src = $img.attr("src").replace(/preview-(.*).png/, `preview-${shape}-${theme}.png`);
+			const src = $img.attr( "src" ).replace( /preview-(.*).png/, `preview-${ shape }-${ theme }.png` )
 
-			$img.attr("src", src);
+			$img.attr( "src", src )
 		},
 
-		changeOsmPreview: function (e) {
-			const type = e.target.id.includes("product") ? "product" : "cart";
+		changeOsmPreview: function ( e ) {
+			const type = e.target.id.includes( "product" ) ? "product" : "cart"
 
-			let placement = $(`#woocommerce_klarna_payments_placement_data_key_${type}`).val();
-			let theme = $(`#woocommerce_klarna_payments_onsite_messaging_theme_${type}`).val();
+			let placement = $( `#woocommerce_klarna_payments_placement_data_key_${ type }` ).val()
+			let theme = $( `#woocommerce_klarna_payments_onsite_messaging_theme_${ type }` ).val()
 
-			const $previewImgs = $(
-				`#klarna-payments-settings-onsite_messaging .kp_settings__section_previews img`
-			);
+			const $previewImgs = $( `#klarna-payments-settings-onsite_messaging .kp_settings__section_previews img` )
 
 			// If we are changing the cart, its the first image, else the second.
-			const index = type === "cart" ? 0 : 1;
-			const $img = $previewImgs.eq(index);
+			const index = type === "cart" ? 0 : 1
+			const $img = $previewImgs.eq( index )
 
 			// Get the img src.
-			const src = $img.attr("src");
+			const src = $img.attr( "src" )
 
 			// Split on the last / to get the path and the filename.
-			const parts = src.split("/");
-			const path = parts.slice(0, -1).join("/");
+			const parts = src.split( "/" )
+			const path = parts.slice( 0, -1 ).join( "/" )
 
-			if ( 'default' === theme || 'custom' === theme || '' === theme ) {
-				theme = 'light';
+			if ( "default" === theme || "custom" === theme || "" === theme ) {
+				theme = "light"
 			}
 
-			if ("" === placement) {
-				placement = "credit-promotion-badge";
+			if ( "" === placement ) {
+				placement = "credit-promotion-badge"
 			}
 
-			const filename = `preview-${type}-${theme}-${placement}.jpg`;
+			const filename = `preview-${ type }-${ theme }-${ placement }.jpg`
 
-			$img.attr("src", `${path}/${filename}`);
+			$img.attr( "src", `${ path }/${ filename }` )
 		},
 
 		updatePreviews: function () {
-			const $previewTargets = $("#woocommerce_klarna_payments_kec_theme, #woocommerce_klarna_payments_kec_shape, #woocommerce_klarna_payments_placement_data_key_product, #woocommerce_klarna_payments_onsite_messaging_theme_product, #woocommerce_klarna_payments_placement_data_key_cart, #woocommerce_klarna_payments_onsite_messaging_theme_cart");
-			$previewTargets.trigger("change");
+			const $previewTargets = $(
+				"#woocommerce_klarna_payments_kec_theme, #woocommerce_klarna_payments_kec_shape, #woocommerce_klarna_payments_placement_data_key_product, #woocommerce_klarna_payments_onsite_messaging_theme_product, #woocommerce_klarna_payments_placement_data_key_cart, #woocommerce_klarna_payments_onsite_messaging_theme_cart",
+			)
+			$previewTargets.trigger( "change" )
 		},
 
-		addSelectAllCountries: function() {
-			const selectAllOption = 'klarna_payments_select_all_countries';
-			const select2Option = 'select2-results__option';
-			const allAreSelected = !$(`.${select2Option}:not(#${selectAllOption})[data-selected="false"]`).length;
-			
+		addSelectAllCountries: function () {
+			const selectAllOption = "klarna_payments_select_all_countries"
+			const select2Option = "select2-results__option"
+			const allAreSelected = ! $( `.${ select2Option }:not(#${ selectAllOption })[data-selected="false"]` ).length
+
 			// If not already added, add the select all option.
-			if(!$(`#${selectAllOption}`).length) {
-				$("#select2-woocommerce_klarna_payments_available_countries-results").prepend(`<li class='${select2Option}' id='${selectAllOption}'><span>${klarna_payments_admin_params.select_all_countries_title}</span></li>`);
+			if ( ! $( `#${ selectAllOption }` ).length ) {
+				$( "#select2-woocommerce_klarna_payments_available_countries-results" ).prepend(
+					`<li class='${ select2Option }' id='${ selectAllOption }'><span>${ klarna_payments_admin_params.select_all_countries_title }</span></li>`,
+				)
 			}
 			// If all countries are already selected, set the select all option as active.
-			$(`#${selectAllOption}`).toggleClass("active", allAreSelected);
+			$( `#${ selectAllOption }` ).toggleClass( "active", allAreSelected )
 		},
-		
-		toggleSelectAll: function() {
-			const selectAllOption = '#klarna_payments_select_all_countries';
-			const isSelectAll = $(`${selectAllOption}`).hasClass("active");
-			const countrySelector = "#woocommerce_klarna_payments_available_countries";
+
+		toggleSelectAll: function () {
+			const selectAllOption = "#klarna_payments_select_all_countries"
+			const isSelectAll = $( `${ selectAllOption }` ).hasClass( "active" )
+			const countrySelector = "#woocommerce_klarna_payments_available_countries"
 
 			// Toggle needed attributes of the country selector dropdown.
-			$(`${countrySelector} option`).prop("selected", !isSelectAll);
-			$(`#select2-woocommerce_klarna_payments_available_countries-results .select2-results__option:not(${selectAllOption})`).attr("data-selected", !isSelectAll);
-			$(`${selectAllOption}`).toggleClass("active", !isSelectAll);
+			$( `${ countrySelector } option` ).prop( "selected", ! isSelectAll )
+			$(
+				`#select2-woocommerce_klarna_payments_available_countries-results .select2-results__option:not(${ selectAllOption })`,
+			).attr( "data-selected", ! isSelectAll )
+			$( `${ selectAllOption }` ).toggleClass( "active", ! isSelectAll )
 			// Trigger needed events to update the country selector dropdown.
-			$(countrySelector).trigger("change");
-			$(".select2-selection__rendered").trigger("scroll");
-		}
-	};
+			$( countrySelector ).trigger( "change" )
+			$( ".select2-selection__rendered" ).trigger( "scroll" )
+		},
+	}
 
-	kp_admin.init();
-});
+	kp_admin.init()
+} )

--- a/assets/js/klarna-payments.js
+++ b/assets/js/klarna-payments.js
@@ -1,6 +1,6 @@
 /* global console, Klarna */
-jQuery(function ($) {
-	"use strict";
+jQuery( function ( $ ) {
+	"use strict"
 
 	var klarna_payments = {
 		authorization_response: {},
@@ -12,295 +12,272 @@ jQuery(function ($) {
 
 		check_changes: function () {
 			$(
-				".woocommerce-billing-fields input, .woocommerce-billing-fields select, .woocommerce-shipping-fields input, .woocommerce-shipping-fields select"
-			).each(function () {
-				var fieldName = $(this).attr("name");
-				var fieldValue = $(this).val();
-				if (klarna_payments.checkout_values[fieldName] !== fieldValue) {
-					klarna_payments.checkout_values[fieldName] = fieldValue;
-					$(this).trigger("change");
+				".woocommerce-billing-fields input, .woocommerce-billing-fields select, .woocommerce-shipping-fields input, .woocommerce-shipping-fields select",
+			).each( function () {
+				var fieldName = $( this ).attr( "name" )
+				var fieldValue = $( this ).val()
+				if ( klarna_payments.checkout_values[ fieldName ] !== fieldValue ) {
+					klarna_payments.checkout_values[ fieldName ] = fieldValue
+					$( this ).trigger( "change" )
 				}
-			});
+			} )
 		},
 
-		debounce_changes: function (func, wait, immediate) {
-			var timeout;
+		debounce_changes: function ( func, wait, immediate ) {
+			var timeout
 			return function () {
 				var context = this,
-					args = arguments;
+					args = arguments
 				var later = function () {
-					timeout = null;
-					if (!immediate) func.apply(context, args);
-				};
-				var callNow = immediate && !timeout;
-				clearTimeout(timeout);
-				timeout = setTimeout(later, wait);
-				if (callNow) func.apply(context, args);
-			};
+					timeout = null
+					if ( ! immediate ) func.apply( context, args )
+				}
+				var callNow = immediate && ! timeout
+				clearTimeout( timeout )
+				timeout = setTimeout( later, wait )
+				if ( callNow ) func.apply( context, args )
+			}
 		},
 
 		start: function () {
 			// Store all billing and shipping values.
-			$(document).ready(function () {
-				$("#customer_details input, #customer_details select").each(
-					function () {
-						var fieldName = $(this).attr("name");
-						var fieldValue = $(this).val();
-						klarna_payments.checkout_values[fieldName] = fieldValue;
-					}
-				);
-				if (klarna_payments.isKlarnaPaymentsSelected()) {
-					klarna_payments.initKlarnaCredit();
-					klarna_payments.load().then(klarna_payments.loadHandler);
+			$( document ).ready( function () {
+				$( "#customer_details input, #customer_details select" ).each( function () {
+					var fieldName = $( this ).attr( "name" )
+					var fieldValue = $( this ).val()
+					klarna_payments.checkout_values[ fieldName ] = fieldValue
+				} )
+				if ( klarna_payments.isKlarnaPaymentsSelected() ) {
+					klarna_payments.initKlarnaCredit()
+					klarna_payments.load().then( klarna_payments.loadHandler )
 				}
-			});
+			} )
 
 			/**
 			 * When WooCommerce updates checkout
 			 * Happens on initial page load, country, state and postal code changes
 			 */
-			$("body").on("updated_checkout", function () {
+			$( "body" ).on( "updated_checkout", function () {
 				// Unblock the payments element if blocked
-				var blocked_el = $(".woocommerce-checkout-payment");
-				var blocked_el_data = blocked_el.data();
-				if (
-					blocked_el.length &&
-					1 === blocked_el_data["blockUI.isBlocked"]
-				) {
-					blocked_el.unblock();
+				var blocked_el = $( ".woocommerce-checkout-payment" )
+				var blocked_el_data = blocked_el.data()
+				if ( blocked_el.length && 1 === blocked_el_data[ "blockUI.isBlocked" ] ) {
+					blocked_el.unblock()
 				}
 
 				// Check if we need to hide the shipping fields
-				klarna_payments.maybeHideShippingAddress();
+				klarna_payments.maybeHideShippingAddress()
 
-				if (klarna_payments.isKlarnaPaymentsSelected()) {
-					klarna_payments.initKlarnaCredit();
-					klarna_payments.load().then(klarna_payments.loadHandler);
+				if ( klarna_payments.isKlarnaPaymentsSelected() ) {
+					klarna_payments.initKlarnaCredit()
+					klarna_payments.load().then( klarna_payments.loadHandler )
 				}
-			});
+			} )
 
 			/**
 			 * Clear auth token if there's checkout error.
 			 */
-			$(document.body).on("checkout_error", function () {
-				$('input[name="klarna_payments_authorization_token"]').remove();
-			});
+			$( document.body ).on( "checkout_error", function () {
+				$( 'input[name="klarna_payments_authorization_token"]' ).remove()
+			} )
 
 			/**
 			 * Phone field changes. Has to be 5 characters or longer for KP to work.
 			 */
-			$("form.checkout").on(
+			$( "form.checkout" ).on(
 				"keyup",
 				"#billing_phone",
-				klarna_payments.debounce_changes(function () {
-					if (klarna_payments.isKlarnaPaymentsSelected()) {
+				klarna_payments.debounce_changes( function () {
+					if ( klarna_payments.isKlarnaPaymentsSelected() ) {
 						//$('#place_order').attr('disabled', true);
-						if ($(this).val().length > 4) {
-							klarna_payments.initKlarnaCredit();
-							klarna_payments
-								.load()
-								.then(klarna_payments.loadHandler);
+						if ( $( this ).val().length > 4 ) {
+							klarna_payments.initKlarnaCredit()
+							klarna_payments.load().then( klarna_payments.loadHandler )
 						}
 					}
-				}, 750)
-			);
+				}, 750 ),
+			)
 
 			/**
 			 * Email field changes, check if WooCommerce says field is valid.
 			 */
-			$("form.checkout").on(
+			$( "form.checkout" ).on(
 				"keyup",
 				"#billing_email",
-				klarna_payments.debounce_changes(function () {
-					if (klarna_payments.isKlarnaPaymentsSelected()) {
+				klarna_payments.debounce_changes( function () {
+					if ( klarna_payments.isKlarnaPaymentsSelected() ) {
 						//$('#place_order').attr('disabled', true);
-						if (!$(this).parent().hasClass("woocommerce-invalid")) {
-							klarna_payments.initKlarnaCredit();
-							klarna_payments
-								.load()
-								.then(klarna_payments.loadHandler);
+						if ( ! $( this ).parent().hasClass( "woocommerce-invalid" ) ) {
+							klarna_payments.initKlarnaCredit()
+							klarna_payments.load().then( klarna_payments.loadHandler )
 						}
 					}
-				}, 750)
-			);
+				}, 750 ),
+			)
 
 			/**
 			 * Billing company field changes.
 			 */
-			$("form.checkout").on(
+			$( "form.checkout" ).on(
 				"keyup",
 				"#billing_company",
-				klarna_payments.debounce_changes(function () {
-					if (klarna_payments.isKlarnaPaymentsSelected()) {
-						klarna_payments.initKlarnaCredit();
-						klarna_payments
-							.load()
-							.then(klarna_payments.loadHandler);
+				klarna_payments.debounce_changes( function () {
+					if ( klarna_payments.isKlarnaPaymentsSelected() ) {
+						klarna_payments.initKlarnaCredit()
+						klarna_payments.load().then( klarna_payments.loadHandler )
 					}
-				}, 750)
-			);
+				}, 750 ),
+			)
 
 			/**
 			 * When changing payment method.
 			 */
-			$("body").on("change", 'input[name="payment_method"]', function () {
+			$( "body" ).on( "change", 'input[name="payment_method"]', function () {
 				// If Klarna Payments is selected and iframe is not loaded yet, disable the form. Also collapse any unselected Klarna Payments gateways.
-				if (klarna_payments.isKlarnaPaymentsSelected()) {
-					klarna_payments.initKlarnaCredit();
-					klarna_payments.load().then(klarna_payments.loadHandler);
-					klarna_payments.collapseGateways();
+				if ( klarna_payments.isKlarnaPaymentsSelected() ) {
+					klarna_payments.initKlarnaCredit()
+					klarna_payments.load().then( klarna_payments.loadHandler )
+					klarna_payments.collapseGateways()
 				}
 
 				// Enable the form if any other payment method is selected.
-				if (!klarna_payments.isKlarnaPaymentsSelected()) {
-					$("#place_order").attr("disabled", false);
+				if ( ! klarna_payments.isKlarnaPaymentsSelected() ) {
+					$( "#place_order" ).attr( "disabled", false )
 				}
 
 				// Check if we need to hide the shipping fields
-				klarna_payments.maybeHideShippingAddress();
-			});
+				klarna_payments.maybeHideShippingAddress()
+			} )
 		},
 
 		load: function () {
-			var $defer = $.Deferred();
+			var $defer = $.Deferred()
 
 			// Dont run load during checkout completion.
-			if ($("form.checkout").hasClass("processing")) {
-				return $defer.reject();
+			if ( $( "form.checkout" ).hasClass( "processing" ) ) {
+				return $defer.reject()
 			}
 
-			var klarna_payments_container_selector_id =
-				"#" + klarna_payments.getSelectorContainerID();
-			console.log(klarna_payments_container_selector_id);
+			var klarna_payments_container_selector_id = "#" + klarna_payments.getSelectorContainerID()
+			console.log( klarna_payments_container_selector_id )
 
-			if (klarna_payments_container_selector_id) {
-				var klarnaLoadedInterval = setInterval(function () {
-					var Klarna = false;
+			if ( klarna_payments_container_selector_id ) {
+				var klarnaLoadedInterval = setInterval( function () {
+					var Klarna = false
 
 					try {
-						Klarna = window.Klarna;
-					} catch (e) {
-						console.debug(e);
+						Klarna = window.Klarna
+					} catch ( e ) {
+						console.debug( e )
 					}
 
-					if (Klarna && Klarna.Payments) {
-						clearInterval(klarnaLoadedInterval);
-						clearTimeout(klarnaLoadedTimeout);
+					if ( Klarna && Klarna.Payments ) {
+						clearInterval( klarnaLoadedInterval )
+						clearTimeout( klarnaLoadedTimeout )
 
 						var options = {
 							container: klarna_payments_container_selector_id,
 							payment_method_category:
-								klarna_payments.getSelectedPaymentCategory() ===
-								"klarna_payments"
+								klarna_payments.getSelectedPaymentCategory() === "klarna_payments"
 									? ""
 									: klarna_payments.getSelectedPaymentCategory(),
-						};
+						}
 
-						if ("US" === $("#billing_country").val()) {
-							var address =
-								klarna_payments.get_address_from_checkout_form();
+						if ( "US" === $( "#billing_country" ).val() ) {
+							var address = klarna_payments.get_address_from_checkout_form()
 
-							Klarna.Payments.load(
-								options,
-								address,
-								function (response) {
-									$defer.resolve(response);
-								}
-							);
+							Klarna.Payments.load( options, address, function ( response ) {
+								$defer.resolve( response )
+							} )
 						} else {
-							Klarna.Payments.load(options, function (response) {
-								$defer.resolve(response);
-							});
+							Klarna.Payments.load( options, function ( response ) {
+								$defer.resolve( response )
+							} )
 						}
 					}
-				}, 100);
+				}, 100 )
 
-				var klarnaLoadedTimeout = setTimeout(function () {
-					clearInterval(klarnaLoadedInterval);
-					$defer.reject();
-				}, 3000);
+				var klarnaLoadedTimeout = setTimeout( function () {
+					clearInterval( klarnaLoadedInterval )
+					$defer.reject()
+				}, 3000 )
 
-				return $defer.promise();
+				return $defer.promise()
 			}
 		},
 
-		loadHandler: function (response) {
-			klarna_payments.iframe_loaded = true;
+		loadHandler: function ( response ) {
+			klarna_payments.iframe_loaded = true
 
-			if (response.show_form) {
-				klarna_payments.show_form = true;
+			if ( response.show_form ) {
+				klarna_payments.show_form = true
 			}
 		},
 
 		isKlarnaPaymentsSelected: function () {
-			if ($('input[name="payment_method"]:checked').length) {
-				var selected_value = $(
-					'input[name="payment_method"]:checked'
-				).val();
-				return selected_value.indexOf("klarna_payments") !== -1;
+			if ( $( 'input[name="payment_method"]:checked' ).length ) {
+				var selected_value = $( 'input[name="payment_method"]:checked' ).val()
+				return selected_value.indexOf( "klarna_payments" ) !== -1
 			}
 
-			return false;
+			return false
 		},
 
 		isTermsAccepted: function () {
-			if(!$('#terms').length || $('#terms').is(':checked')) {
-				return true;
+			if ( ! $( "#terms" ).length || $( "#terms" ).is( ":checked" ) ) {
+				return true
 			}
 
-			return false;
+			return false
 		},
 
 		setRadioButtonValues: function () {
-			$('input[name="payment_method"]').each(function () {
-				if ($(this).val().indexOf("klarna_payments") !== -1) {
-					$(this).val("klarna_payments");
+			$( 'input[name="payment_method"]' ).each( function () {
+				if ( $( this ).val().indexOf( "klarna_payments" ) !== -1 ) {
+					$( this ).val( "klarna_payments" )
 				}
-			});
+			} )
 		},
 
 		getSelectorContainerID: function () {
-			var containerID = $('input[name="payment_method"]:checked')
-				.attr("id")
-				.replace("payment_method_", "");
+			var containerID = $( 'input[name="payment_method"]:checked' ).attr( "id" ).replace( "payment_method_", "" )
 
-			return containerID + "_container";
+			return containerID + "_container"
 		},
 
 		getSelectedPaymentCategory: function () {
-			var selected_category = $('input[name="payment_method"]:checked')
-				.attr("id")
-				.replace("payment_method_", "");
-			console.log(selected_category);
-			return selected_category.replace("klarna_payments_", "");
+			var selected_category = $( 'input[name="payment_method"]:checked' )
+				.attr( "id" )
+				.replace( "payment_method_", "" )
+			console.log( selected_category )
+			return selected_category.replace( "klarna_payments_", "" )
 		},
 
 		authorize: function () {
-			var $defer = $.Deferred();
-			var address = klarna_payments.get_address();
+			var $defer = $.Deferred()
+			var address = klarna_payments.get_address()
 
-			klarna_payments.authorization_response = {};
+			klarna_payments.authorization_response = {}
 
 			try {
 				Klarna.Payments.authorize(
 					address,
 					{
 						payment_method_category:
-							klarna_payments.getSelectedPaymentCategory() ===
-							"klarna_payments"
+							klarna_payments.getSelectedPaymentCategory() === "klarna_payments"
 								? ""
 								: klarna_payments.getSelectedPaymentCategory(),
 					},
-					function (response) {
-						klarna_payments.authorization_response = response;
-						$defer.resolve(response);
-					}
-				);
-			} catch (e) {
-				console.log(e);
+					function ( response ) {
+						klarna_payments.authorization_response = response
+						$defer.resolve( response )
+					},
+				)
+			} catch ( e ) {
+				console.log( e )
 			}
 
-			return $defer.promise();
+			return $defer.promise()
 		},
 
 		get_address: function () {
@@ -314,187 +291,156 @@ jQuery(function ($) {
 					region: klarna_payments.addresses.billing.region,
 					postal_code: klarna_payments.addresses.billing.postal_code,
 					city: klarna_payments.addresses.billing.city,
-					street_address:
-						klarna_payments.addresses.billing.street_address,
-					street_address2:
-						klarna_payments.addresses.billing.street_address2,
+					street_address: klarna_payments.addresses.billing.street_address,
+					street_address2: klarna_payments.addresses.billing.street_address2,
 					organization_name:
 						"b2b" === klarna_payments_params.customer_type
-							? klarna_payments.addresses.billing
-									.organization_name
+							? klarna_payments.addresses.billing.organization_name
 							: "",
 				},
 				shipping_address: {},
-			};
-
-			address.shipping_address = $.extend({}, address.billing_address);
-
-			if ($("#ship-to-different-address").find("input").is(":checked")) {
-				address.shipping_address.given_name =
-					klarna_payments.addresses.shipping.given_name;
-				address.shipping_address.family_name =
-					klarna_payments.addresses.shipping.family_name;
-				address.shipping_address.country =
-					klarna_payments.addresses.shipping.country;
-				address.shipping_address.region =
-					klarna_payments.addresses.shipping.region;
-				address.shipping_address.postal_code =
-					klarna_payments.addresses.shipping.postal_code;
-				address.shipping_address.city =
-					klarna_payments.addresses.shipping.city;
-				address.shipping_address.street_address =
-					klarna_payments.addresses.shipping.street_address;
-				address.shipping_address.street_address2 =
-					klarna_payments.addresses.shipping.street_address2;
 			}
 
-			return address;
+			address.shipping_address = $.extend( {}, address.billing_address )
+
+			if ( $( "#ship-to-different-address" ).find( "input" ).is( ":checked" ) ) {
+				address.shipping_address.given_name = klarna_payments.addresses.shipping.given_name
+				address.shipping_address.family_name = klarna_payments.addresses.shipping.family_name
+				address.shipping_address.country = klarna_payments.addresses.shipping.country
+				address.shipping_address.region = klarna_payments.addresses.shipping.region
+				address.shipping_address.postal_code = klarna_payments.addresses.shipping.postal_code
+				address.shipping_address.city = klarna_payments.addresses.shipping.city
+				address.shipping_address.street_address = klarna_payments.addresses.shipping.street_address
+				address.shipping_address.street_address2 = klarna_payments.addresses.shipping.street_address2
+			}
+
+			return address
 		},
 
 		get_address_from_checkout_form: function () {
 			var address = {
 				billing_address: {
-					given_name:
-						klarna_payments.checkout_values.billing_first_name,
-					family_name:
-						klarna_payments.checkout_values.billing_last_name,
+					given_name: klarna_payments.checkout_values.billing_first_name,
+					family_name: klarna_payments.checkout_values.billing_last_name,
 					email: klarna_payments.checkout_values.billing_email,
 					phone: klarna_payments.checkout_values.billing_phone,
 					country: klarna_payments.checkout_values.billing_country,
 					region: klarna_payments.checkout_values.billing_state,
-					postal_code:
-						klarna_payments.checkout_values.billing_postcode,
+					postal_code: klarna_payments.checkout_values.billing_postcode,
 					city: klarna_payments.checkout_values.billing_city,
-					street_address:
-						klarna_payments.checkout_values.billing_address_1,
-					street_address2:
-						klarna_payments.checkout_values.billing_address_2,
+					street_address: klarna_payments.checkout_values.billing_address_1,
+					street_address2: klarna_payments.checkout_values.billing_address_2,
 					organization_name:
 						"b2b" === klarna_payments_params.customer_type
 							? klarna_payments.checkout_values.billing_company
 							: "",
 				},
 				shipping_address: {},
-			};
-
-			address.shipping_address = $.extend({}, address.billing_address);
-
-			if ($("#ship-to-different-address").find("input").is(":checked")) {
-				address.shipping_address.given_name =
-					klarna_payments.checkout_values.shipping_first_name;
-				address.shipping_address.family_name =
-					klarna_payments.checkout_values.shipping_last_name;
-				address.shipping_address.country =
-					klarna_payments.checkout_values.shipping_country;
-				address.shipping_address.region =
-					klarna_payments.checkout_values.shipping_state;
-				address.shipping_address.postal_code =
-					klarna_payments.checkout_values.shipping_postcode;
-				address.shipping_address.city =
-					klarna_payments.checkout_values.shipping_city;
-				address.shipping_address.street_address =
-					klarna_payments.checkout_values.shipping_address_1;
-				address.shipping_address.street_address2 =
-					klarna_payments.checkout_values.shipping_address_2;
 			}
 
-			return address;
+			address.shipping_address = $.extend( {}, address.billing_address )
+
+			if ( $( "#ship-to-different-address" ).find( "input" ).is( ":checked" ) ) {
+				address.shipping_address.given_name = klarna_payments.checkout_values.shipping_first_name
+				address.shipping_address.family_name = klarna_payments.checkout_values.shipping_last_name
+				address.shipping_address.country = klarna_payments.checkout_values.shipping_country
+				address.shipping_address.region = klarna_payments.checkout_values.shipping_state
+				address.shipping_address.postal_code = klarna_payments.checkout_values.shipping_postcode
+				address.shipping_address.city = klarna_payments.checkout_values.shipping_city
+				address.shipping_address.street_address = klarna_payments.checkout_values.shipping_address_1
+				address.shipping_address.street_address2 = klarna_payments.checkout_values.shipping_address_2
+			}
+
+			return address
 		},
 
 		collapseGateways: function () {
-			$('input[name="payment_method"]').each(function () {
-				if ($(this).is(":checked")) {
-					$(this).siblings("div.payment_box").show();
+			$( 'input[name="payment_method"]' ).each( function () {
+				if ( $( this ).is( ":checked" ) ) {
+					$( this ).siblings( "div.payment_box" ).show()
 				} else {
-					$(this).siblings("div.payment_box").hide();
+					$( this ).siblings( "div.payment_box" ).hide()
 				}
-			});
+			} )
 		},
 
 		maybeHideShippingAddress: function () {
-			if (false !== klarna_payments.isKlarnaPaymentsSelected()) {
-				if ("b2b" === klarna_payments_params.customer_type) {
-					jQuery("#customer_details .col-2").hide();
+			if ( false !== klarna_payments.isKlarnaPaymentsSelected() ) {
+				if ( "b2b" === klarna_payments_params.customer_type ) {
+					jQuery( "#customer_details .col-2" ).hide()
 				}
 			} else {
-				jQuery("#customer_details .col-2").show();
+				jQuery( "#customer_details .col-2" ).show()
 			}
 		},
 
-		initKlarnaCredit: function (client_token) {
-			var client_token = klarna_payments.getClientToken();
-			window.klarnaInitData = { client_token: client_token };
-			Klarna.Payments.init(klarnaInitData);
+		initKlarnaCredit: function ( client_token ) {
+			var client_token = klarna_payments.getClientToken()
+			window.klarnaInitData = { client_token: client_token }
+			Klarna.Payments.init( klarnaInitData )
 		},
 
-		printErrorMessage: function (message) {
-			$("#klarna-payments-error-notice").remove();
-			const is_pay_for_order = (true == klarna_payments_params.pay_for_order);
-			const $target = is_pay_for_order ? $("div.woocommerce-notices-wrapper") : $("form.checkout");
+		printErrorMessage: function ( message ) {
+			$( "#klarna-payments-error-notice" ).remove()
+			const is_pay_for_order = true == klarna_payments_params.pay_for_order
+			const $target = is_pay_for_order ? $( "div.woocommerce-notices-wrapper" ) : $( "form.checkout" )
 
 			$target.prepend(
 				'<div id="klarna-payments-error-notice" class="woocommerce-NoticeGroup"><ul class="woocommerce-error" role="alert"><li>' +
 					message +
-					"</li></ul></div>"
-			);
-			$.scroll_to_notices($target);
+					"</li></ul></div>",
+			)
+			$.scroll_to_notices( $target )
 		},
 
-		authorizeKlarnaOrder: function (order_id, order_key) {
-			klarna_payments.authorize().done(function (response) {
-				if ("authorization_token" in response) {
-					$("body").trigger("kp_auth_success");
-					$.ajax(klarna_payments_params.place_order_url, {
+		authorizeKlarnaOrder: function ( order_id, order_key ) {
+			klarna_payments.authorize().done( function ( response ) {
+				if ( "authorization_token" in response ) {
+					$( "body" ).trigger( "kp_auth_success" )
+					$.ajax( klarna_payments_params.place_order_url, {
 						type: "POST",
 						dataType: "json",
 						async: true,
 						data: {
 							order_key: order_key,
 							order_id: order_id,
-							auth_token:
-								klarna_payments.authorization_response
-									.authorization_token,
+							auth_token: klarna_payments.authorization_response.authorization_token,
 							nonce: klarna_payments_params.place_order_nonce,
 						},
-						success: function (response) {
+						success: function ( response ) {
 							// Log the success.
-							console.log("kp_place_order success");
-							console.log(response);
+							console.log( "kp_place_order success" )
+							console.log( response )
 						},
-						error: function (response) {
+						error: function ( response ) {
 							// Log the error.
-							console.log("kp_place_order error");
-							console.log(response);
+							console.log( "kp_place_order error" )
+							console.log( response )
 						},
-						complete: function (response) {
-							if (response.responseJSON.success === true) {
-								window.location.href =
-									response.responseJSON.data;
+						complete: function ( response ) {
+							if ( response.responseJSON.success === true ) {
+								window.location.href = response.responseJSON.data
 							} else {
-								$("form.checkout")
-									.removeClass("processing")
-									.unblock();
-								$("form.checkout")
-									.find(".input-text, select, input:checkbox")
-									.trigger("validate")
-									.blur();
-								$("form.checkout").trigger("update_checkout");
+								$( "form.checkout" ).removeClass( "processing" ).unblock()
+								$( "form.checkout" )
+									.find( ".input-text, select, input:checkbox" )
+									.trigger( "validate" )
+									.blur()
+								$( "form.checkout" ).trigger( "update_checkout" )
 							}
 						},
-					});
+					} )
 				} else {
-					$("body").trigger("kp_auth_failed");
+					$( "body" ).trigger( "kp_auth_failed" )
 
 					// Re-enable the form.
-					$("body").trigger("updated_checkout");
-					$("form.checkout").removeClass("processing");
-					$("form.checkout").unblock();
+					$( "body" ).trigger( "updated_checkout" )
+					$( "form.checkout" ).removeClass( "processing" )
+					$( "form.checkout" ).unblock()
 
-					console.log("No authorization_token in response");
-					$("form.woocommerce-checkout")
-						.removeClass("processing")
-						.unblock();
-					$.ajax(klarna_payments_params.auth_failed_url, {
+					console.log( "No authorization_token in response" )
+					$( "form.woocommerce-checkout" ).removeClass( "processing" ).unblock()
+					$.ajax( klarna_payments_params.auth_failed_url, {
 						type: "POST",
 						dataType: "json",
 						async: true,
@@ -504,110 +450,94 @@ jQuery(function ($) {
 							order_id: order_id,
 							nonce: klarna_payments_params.auth_failed_nonce,
 						},
-					});
+					} )
 				}
-			});
+			} )
 		},
 
-		klarnaPayForOrder: function (event) {
-			if (klarna_payments.isKlarnaPaymentsSelected()) {
-				event.preventDefault();
+		klarnaPayForOrder: function ( event ) {
+			if ( klarna_payments.isKlarnaPaymentsSelected() ) {
+				event.preventDefault()
 
-				if(!klarna_payments.isTermsAccepted()) {
-					klarna_payments.printErrorMessage(klarna_payments_params.i18n.terms_not_checked);
-					return;
+				if ( ! klarna_payments.isTermsAccepted() ) {
+					klarna_payments.printErrorMessage( klarna_payments_params.i18n.terms_not_checked )
+					return
 				}
 
-				klarna_payments.addresses = klarna_payments_params.addresses;
+				klarna_payments.addresses = klarna_payments_params.addresses
 				klarna_payments.authorizeKlarnaOrder(
 					klarna_payments_params.order_id,
-					klarna_payments_params.order_key
-				);
+					klarna_payments_params.order_key,
+				)
 			}
 		},
 
 		getClientToken: function () {
-			if ($("#kp_client_token").length > 0) {
-				return $("#kp_client_token").val();
+			if ( $( "#kp_client_token" ).length > 0 ) {
+				return $( "#kp_client_token" ).val()
 			} else {
-				return klarna_payments_params.client_token;
+				return klarna_payments_params.client_token
 			}
 		},
 
-		orderSubmit: function (event) {
-			if (klarna_payments.isKlarnaPaymentsSelected()) {
-				event.preventDefault();
+		orderSubmit: function ( event ) {
+			if ( klarna_payments.isKlarnaPaymentsSelected() ) {
+				event.preventDefault()
 
-				if ($("form.checkout").is(".processing")) {
-					return false;
+				if ( $( "form.checkout" ).is( ".processing" ) ) {
+					return false
 				}
 
-				$("form.checkout").addClass("processing");
-				$("form.checkout").block({
+				$( "form.checkout" ).addClass( "processing" )
+				$( "form.checkout" ).block( {
 					message: null,
 					overlayCSS: {
 						background: "#fff",
 						opacity: 0.6,
 					},
-				});
+				} )
 
-				$.ajax({
+				$.ajax( {
 					type: "POST",
 					url: klarna_payments_params.submit_order,
-					data: $("form.checkout").serialize(),
+					data: $( "form.checkout" ).serialize(),
 					dataType: "json",
-					success: function (data) {
+					success: function ( data ) {
 						try {
-							if ("success" === data.result) {
+							if ( "success" === data.result ) {
 								klarna_payments.logToFile(
-									"Successfully placed order. Starting authorization with Klarna"
-								);
-								klarna_payments.addresses = data.addresses;
-								klarna_payments.authorizeKlarnaOrder(
-									data.order_id,
-									data.order_key
-								);
+									"Successfully placed order. Starting authorization with Klarna",
+								)
+								klarna_payments.addresses = data.addresses
+								klarna_payments.authorizeKlarnaOrder( data.order_id, data.order_key )
 							} else {
-								throw "Result failed";
+								throw "Result failed"
 							}
-						} catch (err) {
-							if (data.messages) {
-								klarna_payments.logToFile(
-									"Checkout error | " + data.messages
-								);
-								klarna_payments.failOrder(
-									"submission",
-									data.messages
-								);
+						} catch ( err ) {
+							if ( data.messages ) {
+								klarna_payments.logToFile( "Checkout error | " + data.messages )
+								klarna_payments.failOrder( "submission", data.messages )
 							} else {
-								klarna_payments.logToFile(
-									"Checkout error | " + err
-								);
+								klarna_payments.logToFile( "Checkout error | " + err )
 								klarna_payments.failOrder(
 									"submission",
-									'<div class="woocommerce-error">' +
-										"Checkout error" +
-										"</div>"
-								);
+									'<div class="woocommerce-error">' + "Checkout error" + "</div>",
+								)
 							}
 						}
 					},
-					error: function (data) {
+					error: function ( data ) {
 						try {
-							klarna_payments.logToFile(
-								"AJAX error | " + JSON.stringify(data)
-							);
-						} catch (e) {
-							klarna_payments.logToFile(
-								"AJAX error | Failed to parse error message."
-							);
+							klarna_payments.logToFile( "AJAX error | " + JSON.stringify( data ) )
+						} catch ( e ) {
+							klarna_payments.logToFile( "AJAX error | Failed to parse error message." )
 						}
 						klarna_payments.failOrder(
 							"ajax-error",
-							'<div class="woocommerce-error">Internal Server Error</div>'
-						);
+							'<div class="woocommerce-error">Internal Server Error</div>',
+						)
 					},
-				});
+				} )
 			}
 		},
 
@@ -615,36 +545,29 @@ jQuery(function ($) {
 		 * Fails the order with Klarna on a checkout error and timeout.
 		 * @param {string} event
 		 */
-		failOrder: function (event, error_message) {
+		failOrder: function ( event, error_message ) {
 			// Re-enable the form.
-			$("body").trigger("updated_checkout");
-			$("form.checkout").removeClass("processing");
-			$("form.checkout").unblock();
+			$( "body" ).trigger( "updated_checkout" )
+			$( "form.checkout" ).removeClass( "processing" )
+			$( "form.checkout" ).unblock()
 
 			// Print error messages, and trigger checkout_error, and scroll to notices.
-			$(
-				".woocommerce-NoticeGroup-checkout, .woocommerce-error, .woocommerce-message"
-			).remove();
-			$("form.checkout").prepend(
-				'<div class="woocommerce-NoticeGroup woocommerce-NoticeGroup-checkout">' +
-					error_message +
-					"</div>"
-			); // eslint-disable-line max-len
-			$("form.checkout").removeClass("processing").unblock();
-			$("form.checkout")
-				.find(".input-text, select, input:checkbox")
-				.trigger("validate")
-				.blur();
-			$(document.body).trigger("checkout_error", [error_message]);
-			$.scroll_to_notices($("form.checkout"));
+			$( ".woocommerce-NoticeGroup-checkout, .woocommerce-error, .woocommerce-message" ).remove()
+			$( "form.checkout" ).prepend(
+				'<div class="woocommerce-NoticeGroup woocommerce-NoticeGroup-checkout">' + error_message + "</div>",
+			) // eslint-disable-line max-len
+			$( "form.checkout" ).removeClass( "processing" ).unblock()
+			$( "form.checkout" ).find( ".input-text, select, input:checkbox" ).trigger( "validate" ).blur()
+			$( document.body ).trigger( "checkout_error", [ error_message ] )
+			$.scroll_to_notices( $( "form.checkout" ) )
 		},
 
 		/**
 		 * Logs the message to the klarna payments log in WooCommerce.
 		 * @param {string} message
 		 */
-		logToFile: function (message) {
-			$.ajax({
+		logToFile: function ( message ) {
+			$.ajax( {
 				url: klarna_payments_params.log_to_file_url,
 				type: "POST",
 				dataType: "json",
@@ -652,28 +575,24 @@ jQuery(function ($) {
 					message: message,
 					nonce: klarna_payments_params.log_to_file_nonce,
 				},
-			});
+			} )
 		},
-	};
-	klarna_payments.start();
-	$("body").ready(function () {
-		klarna_payments.setRadioButtonValues();
-	});
+	}
+	klarna_payments.start()
+	$( "body" ).ready( function () {
+		klarna_payments.setRadioButtonValues()
+	} )
 
-	$("body").ajaxComplete(function () {
-		klarna_payments.setRadioButtonValues();
-	});
+	$( "body" ).ajaxComplete( function () {
+		klarna_payments.setRadioButtonValues()
+	} )
 
-	$("body").on(
-		"click",
-		"input#place_order, button#place_order",
-		function (e) {
-			// No strict comparison: wp_localize_script() converts booleans to strings "1", respectively, "0".
-			if (true == klarna_payments_params.pay_for_order) {
-				klarna_payments.klarnaPayForOrder(e);
-			} else {
-				klarna_payments.orderSubmit(e);
-			}
+	$( "body" ).on( "click", "input#place_order, button#place_order", function ( e ) {
+		// No strict comparison: wp_localize_script() converts booleans to strings "1", respectively, "0".
+		if ( true == klarna_payments_params.pay_for_order ) {
+			klarna_payments.klarnaPayForOrder( e )
+		} else {
+			klarna_payments.orderSubmit( e )
 		}
-	);
-});
+	} )
+} )

--- a/classes/class-kp-ajax.php
+++ b/classes/class-kp-ajax.php
@@ -158,9 +158,9 @@ if ( ! class_exists( 'KP_AJAX' ) ) {
 				$order->add_order_note( __( 'Customer aborted purchase with Klarna.', 'klarna-payments-for-woocommerce' ) );
 			} else {
 				$order->add_order_note( __( 'Authorization rejected by Klarna.', 'klarna-payments-for-woocommerce' ) );
-				do_action( 'kp_authorization_rejected', $order );
 			}
 
+			do_action( 'kp_modal_closed', $order, $show_form );
 			wp_send_json_success();
 		}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,8 @@
         "typescript": "^5.6.3",
         "webpack": "^5.74.0",
         "webpack-cli": "^4.10.0",
-        "webpack-dev-server": "^4.11.1"
+        "webpack-dev-server": "^4.11.1",
+        "wp-prettier": "^3.0.3"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -30589,6 +30590,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/wp-prettier": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-3.0.3.tgz",
+      "integrity": "sha512-X4UlrxDTH8oom9qXlcjnydsjAOD2BmB6yFmvS4Z2zdTzqqpRWb+fbqrH412+l+OUXmbzJlSXjlMFYPgYG12IAA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "scripts": {
     "prebuild": "npx grunt makepot && npx grunt cssmin",
-    "format": "pnpx wp-prettier assets/js --paren-spacing --tab-width 4 --print-width 120 --no-semi --write",
+    "format": "npx wp-prettier assets/js --paren-spacing --tab-width 4 --print-width 120 --no-semi --write",
     "build": "npx wp-scripts build",
     "start:webpack": "wp-scripts start",
     "start:dev": "wp-scripts start"

--- a/package.json
+++ b/package.json
@@ -40,10 +40,12 @@
     "typescript": "^5.6.3",
     "webpack": "^5.74.0",
     "webpack-cli": "^4.10.0",
-    "webpack-dev-server": "^4.11.1"
+    "webpack-dev-server": "^4.11.1",
+    "wp-prettier": "^3.0.3"
   },
   "scripts": {
     "prebuild": "npx grunt makepot && npx grunt cssmin",
+    "format": "pnpx wp-prettier assets/js --paren-spacing --tab-width 4 --print-width 120 --no-semi --write",
     "build": "npx wp-scripts build",
     "start:webpack": "wp-scripts start",
     "start:dev": "wp-scripts start"


### PR DESCRIPTION
Allows users to hook onto the `kp_modal_closed` action whenever the purchase is aborted either by the customer (`show_form=true`) or by Klarna (`show_form=false`).