### PR TITLE
Reload if requested on orderSubmit fail

### DIFF
--- a/assets/js/klarna-payments.js
+++ b/assets/js/klarna-payments.js
@@ -579,6 +579,9 @@ jQuery(function ($) {
 									"submission",
 									data.messages
 								);
+							// If requested, reload the page.
+							} else if ( true === data.reload ) {
+								window.location.reload();
 							} else {
 								klarna_payments.logToFile(
 									"Checkout error | " + err


### PR DESCRIPTION
If orderSubmit fails and no error message is given but returned data contains reload: true, reload the checkout.

This is probably not the best of solutions, but the one that I'm able to solve the bug at hand with, at the moment.

**Issue**

When "Allow customers to place orders without an account" is disabled, non-logged in users receive continuous generic checkout errors as they close the payment modal to then clicks "Place order" again.

No error message is returned from WC on the order submit, and only messaging I'm able to see is "We were unable to process your order, please try again".

I'm not sure how often the checkout returns an error without an error message, and with reload set to true (I assume this is suggesting that a reload should take place?). Perhaps this will be triggered too often?

