### PR TITLE
Check if is_created_via exists

### DIFF
--- a/includes/kp-functions.php
+++ b/includes/kp-functions.php
@@ -272,7 +272,7 @@ function kp_is_order_pay_page() {
  * @return bool
  */
 function kp_is_wc_blocks_order( $order ) {
-	return $order && method_exists( $order, 'is_created_via' ) && $order->is_created_via( 'store-api' );
+	return $order && is_a( $order, WC_Order::class ) && $order->is_created_via( 'store-api' );
 }
 
 /**

--- a/includes/kp-functions.php
+++ b/includes/kp-functions.php
@@ -272,7 +272,7 @@ function kp_is_order_pay_page() {
  * @return bool
  */
 function kp_is_wc_blocks_order( $order ) {
-	return $order && $order->is_created_via( 'store-api' );
+	return $order && method_exists( $order, 'is_created_via' ) && $order->is_created_via( 'store-api' );
 }
 
 /**


### PR DESCRIPTION
Check if `is_created_via()` exists in check if order is made through the WC blocks checkout, to solve the error "PHP Fatal error: Uncaught Error: Call to undefined method WC_Order::is_created_via()" on checkout, reported [here](https://github.com/krokedil/klarna-payments-for-woocommerce/issues/369).

I'm not able to replicate this. I assume it occurs in a very specific situation, or in an old version of WooCommerce (before 4.0.0, when `is_created_via()` was introduced). This check should at least work well for older versions, as they obviously would not have block checkout support either way, and `kp_is_wc_blocks_order` would thus correctly simply return `false`.

Perhaps this shouldn't be covered for at all?