### PR TITLE
Remove hardcoded unavailable feature

### DIFF
--- a/includes/kp-functions.php
+++ b/includes/kp-functions.php
@@ -454,7 +454,7 @@ function kp_map_unavailable_features( $collected_features ) {
 		}
 
 		if ( null === $features[ $feature_category ]['status'] ) {
-			$features['platform-plugin-payments']['status'] = false;
+			$features[ $feature_category ]['status'] = false;
 		}
 
 		if ( 'AVAILABLE' === $collected_feature['availability'] ) {


### PR DESCRIPTION
To resolve issue with KP sometimes being unavailable for credentials where another feature should be unavailable.