### PR TITLE
Do not allow status badge on new line

### DIFF
--- a/assets/css/klarna-payments-admin.css
+++ b/assets/css/klarna-payments-admin.css
@@ -413,6 +413,7 @@ div.kp_settings__section_content .kp_settings__content_gradient {
 	padding: 5px 10px;
 	font-size: 12px;
 	font-weight: 700;
+	white-space: nowrap;
 }
 
 .kp_settings__mode_badge.active {
@@ -447,7 +448,7 @@ div.kp_settings__section_content .kp_settings__content_gradient {
 
 .kp_settings__section_title {
 	display: flex;
-	flex-wrap: wrap;
+	flex-wrap: nowrap;
 	align-items: center;
 	gap: 5px;
 }


### PR DESCRIPTION
Do not allow wrapping on the title content on KP settings page, to avoid the status badge sometimes breaking to a new line depending on the viewport size.