### PR TITLE
Tweak cart_has_subscription

### DIFF
--- a/classes/class-kp-subscriptions.php
+++ b/classes/class-kp-subscriptions.php
@@ -359,7 +359,6 @@ class KP_Subscription {
 		( function_exists( 'wcs_cart_contains_renewal' ) && wcs_cart_contains_renewal() ) ||
 		( function_exists( 'wcs_cart_contains_failed_renewal_order_payment' ) && wcs_cart_contains_failed_renewal_order_payment() ) ||
 		( function_exists( 'wcs_cart_contains_resubscribe' ) && wcs_cart_contains_resubscribe() ) ||
-		( function_exists( 'wcs_cart_contains_subscription_switch' ) && wcs_cart_contains_subscription_switch() ) ||
 		( function_exists( 'wcs_cart_contains_early_renewal' ) && wcs_cart_contains_early_renewal() ) ||
 		( function_exists( 'wcs_cart_contains_switches' ) && wcs_cart_contains_switches() )
 		);

--- a/classes/class-kp-subscriptions.php
+++ b/classes/class-kp-subscriptions.php
@@ -354,7 +354,19 @@ class KP_Subscription {
 			return false;
 		}
 
-		return ( class_exists( 'WC_Subscriptions_Cart' ) && WC_Subscriptions_Cart::cart_contains_subscription() ) || ( function_exists( 'wcs_cart_contains_failed_renewal_order_payment' ) && wcs_cart_contains_failed_renewal_order_payment() );
+		$cart          = WC()->cart->get_cart();
+		$product_types = array_values(
+			array_unique(
+				array_map(
+					function ( $item ) {
+						return wc_get_product( $item['product_id'] )->get_type();
+					},
+					$cart
+				)
+			)
+		);
+
+		return array_intersect( array( 'subscription', 'subscription_variation' ), $product_types );
 	}
 
 	/**

--- a/classes/class-kp-subscriptions.php
+++ b/classes/class-kp-subscriptions.php
@@ -345,7 +345,7 @@ class KP_Subscription {
 	}
 
 	/**
-	 * Check if a cart contains a subscription.
+	 * Check if a cart contains a subscription-related item.
 	 *
 	 * @return bool
 	 */
@@ -354,19 +354,15 @@ class KP_Subscription {
 			return false;
 		}
 
-		$cart          = WC()->cart->get_cart();
-		$product_types = array_values(
-			array_unique(
-				array_map(
-					function ( $item ) {
-						return wc_get_product( $item['product_id'] )->get_type();
-					},
-					$cart
-				)
-			)
+		return (
+		( class_exists( 'WC_Subscriptions_Cart' ) && WC_Subscriptions_Cart::cart_contains_subscription() ) ||
+		( function_exists( 'wcs_cart_contains_renewal' ) && wcs_cart_contains_renewal() ) ||
+		( function_exists( 'wcs_cart_contains_failed_renewal_order_payment' ) && wcs_cart_contains_failed_renewal_order_payment() ) ||
+		( function_exists( 'wcs_cart_contains_resubscribe' ) && wcs_cart_contains_resubscribe() ) ||
+		( function_exists( 'wcs_cart_contains_subscription_switch' ) && wcs_cart_contains_subscription_switch() ) ||
+		( function_exists( 'wcs_cart_contains_early_renewal' ) && wcs_cart_contains_early_renewal() ) ||
+		( function_exists( 'wcs_cart_contains_switches' ) && wcs_cart_contains_switches() )
 		);
-
-		return array_intersect( array( 'subscription', 'subscription_variation' ), $product_types );
 	}
 
 	/**


### PR DESCRIPTION
Tweak `cart_has_subscription` to see if any cart items has a subscription product type, to avoid error "Not allowed to create customer token for intent buy" on attempt to create a subscription renewal order.

This should be true for all types of subscription products created by the WooCommerce Subscriptions plugin, regardless of renewal or not. Tested for renewal and new subscriptions.

I think this could be a more waterproof solution? I'm unfortunately not seeing that the subscriptions plugin has a general method to check for any type of subscription product.

Should a general check to make sure that the subscription plugin is active be added, before extracting the product types?