### PR TITLE
Remove metadata

### DIFF
--- a/classes/requests/post/class-kp-unavailable-features.php
+++ b/classes/requests/post/class-kp-unavailable-features.php
@@ -82,7 +82,6 @@ class KP_Unavailable_Features extends KP_Requests_Post {
 						get_site_url(),
 					),
 				),
-				'metadata'           => array(),
 			),
 		);
 	}


### PR DESCRIPTION
Remove metadata, as no data is sent. This resolves a 422 error from the Klarna API, as metdata needs to be an object if to be sent in the future.