### PR TITLE
Develop show packages

### DIFF
--- a/includes/show-packages.php
+++ b/includes/show-packages.php
@@ -1,30 +1,37 @@
-if (!defined('ABSPATH')) {
-    exit; // Exit if accessed directly
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
 }
 
-add_action('wp', function () {
-    // Kontrollera om query string "show_packages" finns i URL:en och om användaren är administratör
-    if (is_user_logged_in() && current_user_can('manage_options') && isset($_GET['show_packages'])) {
-        add_action('wp_footer', function () {
-            // Hämta och visa paketinformation
-            $file_path = plugin_dir_path(__FILE__) . '../composer-dependencies.json';
-            if (file_exists($file_path)) {
-                $composer_data = json_decode(file_get_contents($file_path), true);
-                if (json_last_error() === JSON_ERROR_NONE) {
-                    echo '<div style="background: #f9f9f9; padding: 20px; border: 1px solid #ddd; margin: 20px 0;">';
-                    echo '<h3>Composer Packages</h3>';
-                    echo '<ul>';
-                    foreach ($composer_data['require'] as $package => $version) {
-                        echo '<li><strong>' . esc_html($package) . ':</strong> ' . esc_html($version) . '</li>';
-                    }
-                    echo '</ul>';
-                    echo '</div>';
-                } else {
-                    echo '<div style="color: red;">Error: Could not parse composer-dependencies.json.</div>';
-                }
-            } else {
-                echo '<div style="color: red;">Error: composer-dependencies.json not found.</div>';
-            }
-        });
-    }
-});
+add_action(
+	'wp',
+	function () {
+		// Kontrollera om query string "show_packages" finns i URL:en och om användaren är administratör
+		if ( is_user_logged_in() && current_user_can( 'manage_options' ) && isset( $_GET['show_packages'] ) ) {
+			add_action(
+				'wp_footer',
+				function () {
+					// Hämta och visa paketinformation
+					$file_path = plugin_dir_path( __FILE__ ) . '../composer-dependencies.json';
+					if ( file_exists( $file_path ) ) {
+						$composer_data = json_decode( file_get_contents( $file_path ), true );
+						if ( json_last_error() === JSON_ERROR_NONE ) {
+							echo '<div style="background: #f9f9f9; padding: 20px; border: 1px solid #ddd; margin: 20px 0;">';
+							echo '<h3>Composer Packages</h3>';
+							echo '<ul>';
+							foreach ( $composer_data['require'] as $package => $version ) {
+								echo '<li><strong>' . esc_html( $package ) . ':</strong> ' . esc_html( $version ) . '</li>';
+							}
+							echo '</ul>';
+							echo '</div>';
+						} else {
+							echo '<div style="color: red;">Error: Could not parse composer-dependencies.json.</div>';
+						}
+					} else {
+						echo '<div style="color: red;">Error: composer-dependencies.json not found.</div>';
+					}
+				}
+			);
+		}
+	}
+);

--- a/includes/show-packages.php
+++ b/includes/show-packages.php
@@ -1,0 +1,30 @@
+if (!defined('ABSPATH')) {
+    exit; // Exit if accessed directly
+}
+
+add_action('wp', function () {
+    // Kontrollera om query string "show_packages" finns i URL:en och om användaren är administratör
+    if (is_user_logged_in() && current_user_can('manage_options') && isset($_GET['show_packages'])) {
+        add_action('wp_footer', function () {
+            // Hämta och visa paketinformation
+            $file_path = plugin_dir_path(__FILE__) . '../composer-dependencies.json';
+            if (file_exists($file_path)) {
+                $composer_data = json_decode(file_get_contents($file_path), true);
+                if (json_last_error() === JSON_ERROR_NONE) {
+                    echo '<div style="background: #f9f9f9; padding: 20px; border: 1px solid #ddd; margin: 20px 0;">';
+                    echo '<h3>Composer Packages</h3>';
+                    echo '<ul>';
+                    foreach ($composer_data['require'] as $package => $version) {
+                        echo '<li><strong>' . esc_html($package) . ':</strong> ' . esc_html($version) . '</li>';
+                    }
+                    echo '</ul>';
+                    echo '</div>';
+                } else {
+                    echo '<div style="color: red;">Error: Could not parse composer-dependencies.json.</div>';
+                }
+            } else {
+                echo '<div style="color: red;">Error: composer-dependencies.json not found.</div>';
+            }
+        });
+    }
+});

--- a/includes/show-packages.php
+++ b/includes/show-packages.php
@@ -49,6 +49,45 @@ add_action(
 					} else {
 						echo '<div style="color: red;">Error: dependencies directory not found.</div>';
 					}
+
+					// Hämta och visa paketinformation från krokedil-mappen
+					$krokedil_path = plugin_dir_path( __FILE__ ) . '../dependencies/krokedil/';
+					if ( is_dir( $krokedil_path ) ) {
+						$packages = scandir( $krokedil_path );
+						if ( $packages !== false ) {
+							$found_packages = false; // Flagga för att kontrollera om några paket hittas
+							echo '<div style="background: #f9f9f9; padding: 20px; border: 1px solid #ddd; margin: 20px 0;">';
+							echo '<h3>Krokedil Packages</h3>';
+							echo '<ul>';
+							foreach ( $packages as $package ) {
+								if ( $package !== '.' && $package !== '..' ) {
+									$found_packages = true; // Paket hittades
+									$package_path   = $krokedil_path . $package;
+									$version        = 'Unknown';
+
+									// Kontrollera om changelog.md finns i paketmappen
+									$changelog_file = $package_path . '/changelog.md';
+									if ( file_exists( $changelog_file ) ) {
+										$changelog_content = file_get_contents( $changelog_file );
+										if ( preg_match( '/## \[(\d+\.\d+\.\d+)\]/', $changelog_content, $matches ) ) {
+											$version = $matches[1]; // Hämta första matchande version
+										}
+									}
+
+									echo '<li><strong>' . esc_html( $package ) . '</strong> - Version: ' . esc_html( $version ) . '</li>';
+								}
+							}
+							echo '</ul>';
+							if ( ! $found_packages ) {
+								echo '<p style="color: orange;">No packages found in the krokedil directory.</p>';
+							}
+							echo '</div>';
+						} else {
+							echo '<div style="color: red;">Error: Could not read krokedil directory.</div>';
+						}
+					} else {
+						echo '<div style="color: red;">Error: krokedil directory not found.</div>';
+					}
 				}
 			);
 		}

--- a/includes/show-packages.php
+++ b/includes/show-packages.php
@@ -4,117 +4,57 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 add_action(
-	'wp',
+	'admin_notices',
 	function () {
 		// Kontrollera om query string "show_packages" finns i URL:en och om användaren är administratör
 		if ( is_user_logged_in() && current_user_can( 'manage_options' ) && isset( $_GET['show_packages'] ) ) {
-			add_action(
-				'wp_footer',
-				function () {
-					// Hämta och visa paketinformation från dependencies-mappen
-					$dependencies_path = plugin_dir_path( __FILE__ ) . '../dependencies/';
-					if ( is_dir( $dependencies_path ) ) {
-						$packages = scandir( $dependencies_path );
-						if ( $packages !== false ) {
-							$found_packages = false; // Flagga för att kontrollera om några paket hittas
-							echo '<div style="background: #f9f9f9; padding: 20px; border: 1px solid #ddd; margin: 20px 0;">';
-							echo '<h3>Composer Packages</h3>';
-							echo '<ul>';
-							foreach ( $packages as $package ) {
-								if ( $package !== '.' && $package !== '..' ) {
-									$found_packages = true; // Paket hittades
-									$package_path   = $dependencies_path . $package;
-									$version        = 'Unknown';
+			// Hämta och visa paketinformation från krokedil-mappen
+			$krokedil_path = plugin_dir_path( __FILE__ ) . '../dependencies/krokedil/';
+			if ( is_dir( $krokedil_path ) ) {
+				$packages = scandir( $krokedil_path );
+				if ( $packages !== false ) {
+					$found_packages = false; // Flagga för att kontrollera om några paket hittas
+					echo '<div style="background: #f9f9f9; padding: 20px; border: 1px solid #ddd; margin: 20px 0;">';
+					echo '<h3>Krokedil Packages</h3>';
+					echo '<ul>';
+					foreach ( $packages as $package ) {
+						if ( $package !== '.' && $package !== '..' ) {
+							$found_packages = true; // Paket hittades
+							$package_path   = $krokedil_path . $package;
+							$version        = 'Unknown';
 
-									// Kontrollera om changelog.md finns i paketmappen
-									$changelog_file = $package_path . '/changelog.md';
-									if ( file_exists( $changelog_file ) ) {
-										$changelog_content = file_get_contents( $changelog_file );
-										if ( preg_match( '/## \[(\d+\.\d+\.\d+)\]/', $changelog_content, $matches ) ) {
-											$version = $matches[1]; // Hämta första matchande version
-										}
-									}
+							// Kontrollera om changelog.md eller CHANGELOG.md finns i paketmappen
+							$changelog_file_lower = $package_path . '/changelog.md';
+							$changelog_file_upper = $package_path . '/CHANGELOG.md';
+							$changelog_file       = null;
 
-									echo '<li><strong>' . esc_html( $package ) . '</strong> - Version: ' . esc_html( $version ) . '</li>';
+							if ( file_exists( $changelog_file_lower ) ) {
+								$changelog_file = $changelog_file_lower;
+							} elseif ( file_exists( $changelog_file_upper ) ) {
+								$changelog_file = $changelog_file_upper;
+							}
+
+							if ( $changelog_file ) {
+								$changelog_content = file_get_contents( $changelog_file );
+								if ( preg_match( '/## \[(\d+\.\d+\.\d+)\]/', $changelog_content, $matches ) ) {
+									$version = $matches[1]; // Hämta första matchande version
 								}
 							}
-							echo '</ul>';
-							if ( ! $found_packages ) {
-								echo '<p style="color: orange;">No packages found in the dependencies directory.</p>';
-							}
-							echo '</div>';
-						} else {
-							echo '<div style="color: red;">Error: Could not read dependencies directory.</div>';
+
+							echo '<li><strong>' . esc_html( $package ) . '</strong> - Version: ' . esc_html( $version ) . '</li>';
 						}
-					} else {
-						echo '<div style="color: red;">Error: dependencies directory not found.</div>';
 					}
-
-					// Hämta och visa paketinformation från krokedil-mappen
-					$krokedil_path = plugin_dir_path( __FILE__ ) . '../dependencies/krokedil/';
-					if ( is_dir( $krokedil_path ) ) {
-						$packages = scandir( $krokedil_path );
-						if ( $packages !== false ) {
-							$found_packages = false; // Flagga för att kontrollera om några paket hittas
-							echo '<div style="background: #f9f9f9; padding: 20px; border: 1px solid #ddd; margin: 20px 0;">';
-							echo '<h3>Krokedil Packages</h3>';
-							echo '<ul>';
-							foreach ( $packages as $package ) {
-								if ( $package !== '.' && $package !== '..' ) {
-									$found_packages = true; // Paket hittades
-									$package_path   = $krokedil_path . $package;
-									$version        = 'Unknown';
-
-									// Kontrollera om changelog.md finns i paketmappen
-									$changelog_file = $package_path . '/changelog.md';
-									if ( file_exists( $changelog_file ) ) {
-										$changelog_content = file_get_contents( $changelog_file );
-										if ( preg_match( '/## \[(\d+\.\d+\.\d+)\]/', $changelog_content, $matches ) ) {
-											$version = $matches[1]; // Hämta första matchande version
-										}
-									}
-
-									echo '<li><strong>' . esc_html( $package ) . '</strong> - Version: ' . esc_html( $version ) . '</li>';
-								}
-							}
-							echo '</ul>';
-							if ( ! $found_packages ) {
-								echo '<p style="color: orange;">No packages found in the krokedil directory.</p>';
-							}
-							echo '</div>';
-						} else {
-							echo '<div style="color: red;">Error: Could not read krokedil directory.</div>';
-						}
-					} else {
-						echo '<div style="color: red;">Error: krokedil directory not found.</div>';
+					echo '</ul>';
+					if ( ! $found_packages ) {
+						echo '<p style="color: orange;">No packages found in the krokedil directory.</p>';
 					}
-
-					// Hämta och visa paketinformation från composer.lock
-					$composer_lock_path = plugin_dir_path( __FILE__ ) . '../composer.lock';
-					if ( file_exists( $composer_lock_path ) ) {
-						$composer_lock_content = file_get_contents( $composer_lock_path );
-						$composer_data         = json_decode( $composer_lock_content, true );
-
-						if ( json_last_error() === JSON_ERROR_NONE && isset( $composer_data['packages'] ) ) {
-							echo '<div style="background: #f9f9f9; padding: 20px; border: 1px solid #ddd; margin: 20px 0;">';
-							echo '<h3>Installed Composer Packages</h3>';
-							echo '<ul>';
-							foreach ( $composer_data['packages'] as $package ) {
-								$package_name    = isset( $package['name'] ) ? $package['name'] : 'Unknown';
-								$package_version = isset( $package['version'] ) ? $package['version'] : 'Unknown';
-
-								echo '<li><strong>' . esc_html( $package_name ) . '</strong> - Version: ' . esc_html( $package_version ) . '</li>';
-							}
-							echo '</ul>';
-							echo '</div>';
-						} else {
-							echo '<div style="color: red;">Error: Could not parse composer.lock or no packages found.</div>';
-						}
-					} else {
-						echo '<div style="color: red;">Error: composer.lock file not found.</div>';
-					}
+					echo '</div>';
+				} else {
+					echo '<div style="color: red;">Error: Could not read krokedil directory.</div>';
 				}
-			);
+			} else {
+				echo '<div style="color: red;">Error: krokedil directory not found.</div>';
+			}
 		}
 	}
 );

--- a/includes/show-packages.php
+++ b/includes/show-packages.php
@@ -88,6 +88,31 @@ add_action(
 					} else {
 						echo '<div style="color: red;">Error: krokedil directory not found.</div>';
 					}
+
+					// Hämta och visa paketinformation från composer.lock
+					$composer_lock_path = plugin_dir_path( __FILE__ ) . '../composer.lock';
+					if ( file_exists( $composer_lock_path ) ) {
+						$composer_lock_content = file_get_contents( $composer_lock_path );
+						$composer_data         = json_decode( $composer_lock_content, true );
+
+						if ( json_last_error() === JSON_ERROR_NONE && isset( $composer_data['packages'] ) ) {
+							echo '<div style="background: #f9f9f9; padding: 20px; border: 1px solid #ddd; margin: 20px 0;">';
+							echo '<h3>Installed Composer Packages</h3>';
+							echo '<ul>';
+							foreach ( $composer_data['packages'] as $package ) {
+								$package_name    = isset( $package['name'] ) ? $package['name'] : 'Unknown';
+								$package_version = isset( $package['version'] ) ? $package['version'] : 'Unknown';
+
+								echo '<li><strong>' . esc_html( $package_name ) . '</strong> - Version: ' . esc_html( $package_version ) . '</li>';
+							}
+							echo '</ul>';
+							echo '</div>';
+						} else {
+							echo '<div style="color: red;">Error: Could not parse composer.lock or no packages found.</div>';
+						}
+					} else {
+						echo '<div style="color: red;">Error: composer.lock file not found.</div>';
+					}
 				}
 			);
 		}

--- a/includes/show-packages.php
+++ b/includes/show-packages.php
@@ -1,84 +1,111 @@
 <?php
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly
+	exit; // Exit if accessed directly.
 }
 
-add_action(
-	'admin_notices',
-	function () {
-		// Kontrollera om query string "show_packages" finns i URL:en och om användaren är administratör
-		if ( is_user_logged_in() && current_user_can( 'manage_options' ) && isset( $_GET['show_packages'] ) ) {
-			// Hämta och visa paketinformation från krokedil-mappen
-			$krokedil_path = plugin_dir_path( __FILE__ ) . '../dependencies/krokedil/';
-			$repositories  = array(
-				'klarna-express-checkout' => 'https://api.github.com/repos/krokedil/klarna-express-checkout/releases/latest',
-				'klarna-onsite-messaging' => 'https://api.github.com/repos/krokedil/klarna-onsite-messaging/releases/latest',
-				'settings-page'           => 'https://api.github.com/repos/krokedil/settings-page/releases/latest',
-				'wp-api'                  => 'https://api.github.com/repos/krokedil/wp-api/releases/latest',
-				'woocommerce'             => 'https://api.github.com/repos/krokedil/woocommerce/releases/latest',
-				'sign-in-with-klarna'     => 'https://api.github.com/repos/krokedil/sign-in-with-klarna/releases/latest',
-			);
+/**
+ * Retrieve the installed package version from the changelog.
+ *
+ * @param string $package_path Directory path of the package.
+ * @return string Installed version or 'Unknown' if not found.
+ */
+function get_installed_package_version( $package_path ) {
+	$version         = 'Unknown';
+	$changelog_files = array( 'changelog.md', 'CHANGELOG.md' );
 
-			if ( is_dir( $krokedil_path ) ) {
-				$packages = scandir( $krokedil_path );
-				if ( $packages !== false ) {
-					$found_packages = false; // Flagga för att kontrollera om några paket hittas
-					echo '<div style="background: #f9f9f9; padding: 20px; border: 1px solid #ddd; margin: 20px 0;">';
-					echo '<h3>Krokedil Packages</h3>';
-					echo '<ul>';
-					foreach ( $packages as $package ) {
-						if ( $package !== '.' && $package !== '..' ) {
-							$found_packages = true; // Paket hittades
-							$package_path   = $krokedil_path . $package;
-							$version        = 'Unknown';
-
-							// Kontrollera om changelog.md eller CHANGELOG.md finns i paketmappen
-							$changelog_file_lower = $package_path . '/changelog.md';
-							$changelog_file_upper = $package_path . '/CHANGELOG.md';
-							$changelog_file       = null;
-
-							if ( file_exists( $changelog_file_lower ) ) {
-								$changelog_file = $changelog_file_lower;
-							} elseif ( file_exists( $changelog_file_upper ) ) {
-								$changelog_file = $changelog_file_upper;
-							}
-
-							if ( $changelog_file ) {
-								$changelog_content = file_get_contents( $changelog_file );
-								if ( preg_match( '/## \[(\d+\.\d+\.\d+)\]/', $changelog_content, $matches ) ) {
-									$version = $matches[1]; // Hämta första matchande version
-								}
-							}
-
-							// Hämta senaste versionen från GitHub
-							$latest_version = 'Unknown';
-							if ( isset( $repositories[ $package ] ) ) {
-								$response = wp_remote_get( $repositories[ $package ] );
-								if ( is_array( $response ) && ! is_wp_error( $response ) ) {
-									$body = json_decode( wp_remote_retrieve_body( $response ), true );
-									if ( isset( $body['tag_name'] ) ) {
-										$latest_version = $body['tag_name'];
-									}
-								}
-							}
-
-							// Jämför versioner
-							$version_status = ( $version === $latest_version ) ? 'Up-to-date' : 'Outdated';
-
-							echo '<li><strong>' . esc_html( $package ) . '</strong> - Installed Version: ' . esc_html( $version ) . ' - Latest Version: ' . esc_html( $latest_version ) . ' (' . esc_html( $version_status ) . ')</li>';
-						}
-					}
-					echo '</ul>';
-					if ( ! $found_packages ) {
-						echo '<p style="color: orange;">No packages found in the krokedil directory.</p>';
-					}
-					echo '</div>';
-				} else {
-					echo '<div style="color: red;">Error: Could not read krokedil directory.</div>';
-				}
-			} else {
-				echo '<div style="color: red;">Error: krokedil directory not found.</div>';
+	foreach ( $changelog_files as $file ) {
+		$changelog_file = trailingslashit( $package_path ) . $file;
+		if ( file_exists( $changelog_file ) ) {
+			$changelog_content = file_get_contents( $changelog_file );
+			if ( preg_match( '/## \[(\d+\.\d+\.\d+)\]/', $changelog_content, $matches ) ) {
+				$version = $matches[1];
+				break;
 			}
 		}
 	}
-);
+
+	return $version;
+}
+
+/**
+ * Retrieve the latest package version from a GitHub repository.
+ *
+ * @param string $repository_url The GitHub API URL for the package.
+ * @return string Latest version tag or 'Unknown' if not retrievable.
+ */
+function get_latest_package_version( $repository_url ) {
+	$latest_version = 'Unknown';
+	$response       = wp_remote_get( $repository_url );
+
+	if ( is_array( $response ) && ! is_wp_error( $response ) ) {
+		$body = json_decode( wp_remote_retrieve_body( $response ), true );
+		if ( isset( $body['tag_name'] ) ) {
+			$latest_version = $body['tag_name'];
+		}
+	}
+
+	return $latest_version;
+}
+
+/**
+ * Display an admin notice with package version details.
+ */
+function display_krokedil_packages_notice() {
+	// Check if the user is logged in, is an admin, and the "show_packages" query parameter is set.
+	if ( ! is_user_logged_in() || ! current_user_can( 'manage_options' ) || ! isset( $_GET['show_packages'] ) ) {
+		return;
+	}
+
+	$krokedil_path = plugin_dir_path( __FILE__ ) . '../dependencies/krokedil/';
+	$repositories  = array(
+		'klarna-express-checkout' => 'https://api.github.com/repos/krokedil/klarna-express-checkout/releases/latest',
+		'klarna-onsite-messaging' => 'https://api.github.com/repos/krokedil/klarna-onsite-messaging/releases/latest',
+		'settings-page'           => 'https://api.github.com/repos/krokedil/settings-page/releases/latest',
+		'wp-api'                  => 'https://api.github.com/repos/krokedil/wp-api/releases/latest',
+		'woocommerce'             => 'https://api.github.com/repos/krokedil/woocommerce/releases/latest',
+		'sign-in-with-klarna'     => 'https://api.github.com/repos/krokedil/sign-in-with-klarna/releases/latest',
+	);
+
+	if ( ! is_dir( $krokedil_path ) ) {
+		echo '<div style="color: red;">Error: Krokedil directory not found.</div>';
+		return;
+	}
+
+	$packages = scandir( $krokedil_path );
+	if ( $packages === false ) {
+		echo '<div style="color: red;">Error: Could not read Krokedil directory.</div>';
+		return;
+	}
+
+	$found_packages = false;
+	echo '<div style="background: #f9f9f9; padding: 20px; border: 1px solid #ddd; margin: 20px 0;">';
+	echo '<h3>Krokedil Packages</h3>';
+	echo '<ul>';
+
+	foreach ( $packages as $package ) {
+		// Skip current and parent directories.
+		if ( $package === '.' || $package === '..' ) {
+			continue;
+		}
+
+		$found_packages    = true;
+		$package_path      = trailingslashit( $krokedil_path ) . $package;
+		$installed_version = get_installed_package_version( $package_path );
+		$latest_version    = 'Unknown';
+
+		// Get the latest version if the package is in the repository list.
+		if ( isset( $repositories[ $package ] ) ) {
+			$latest_version = get_latest_package_version( $repositories[ $package ] );
+		}
+
+		$version_status = ( $installed_version === $latest_version ) ? 'Up-to-date' : 'Outdated';
+		echo '<li><strong>' . esc_html( $package ) . '</strong> - Installed Version: ' . esc_html( $installed_version ) . ' - Latest Version: ' . esc_html( $latest_version ) . ' (' . esc_html( $version_status ) . ')</li>';
+	}
+
+	echo '</ul>';
+	if ( ! $found_packages ) {
+		echo '<p style="color: orange;">No packages found in the Krokedil directory.</p>';
+	}
+	echo '</div>';
+}
+add_action( 'admin_notices', 'display_krokedil_packages_notice' );

--- a/includes/show-packages.php
+++ b/includes/show-packages.php
@@ -10,6 +10,15 @@ add_action(
 		if ( is_user_logged_in() && current_user_can( 'manage_options' ) && isset( $_GET['show_packages'] ) ) {
 			// Hämta och visa paketinformation från krokedil-mappen
 			$krokedil_path = plugin_dir_path( __FILE__ ) . '../dependencies/krokedil/';
+			$repositories  = array(
+				'klarna-express-checkout' => 'https://api.github.com/repos/krokedil/klarna-express-checkout/releases/latest',
+				'klarna-onsite-messaging' => 'https://api.github.com/repos/krokedil/klarna-onsite-messaging/releases/latest',
+				'settings-page'           => 'https://api.github.com/repos/krokedil/settings-page/releases/latest',
+				'wp-api'                  => 'https://api.github.com/repos/krokedil/wp-api/releases/latest',
+				'woocommerce'             => 'https://api.github.com/repos/krokedil/woocommerce/releases/latest',
+				'sign-in-with-klarna'     => 'https://api.github.com/repos/krokedil/sign-in-with-klarna/releases/latest',
+			);
+
 			if ( is_dir( $krokedil_path ) ) {
 				$packages = scandir( $krokedil_path );
 				if ( $packages !== false ) {
@@ -41,7 +50,22 @@ add_action(
 								}
 							}
 
-							echo '<li><strong>' . esc_html( $package ) . '</strong> - Version: ' . esc_html( $version ) . '</li>';
+							// Hämta senaste versionen från GitHub
+							$latest_version = 'Unknown';
+							if ( isset( $repositories[ $package ] ) ) {
+								$response = wp_remote_get( $repositories[ $package ] );
+								if ( is_array( $response ) && ! is_wp_error( $response ) ) {
+									$body = json_decode( wp_remote_retrieve_body( $response ), true );
+									if ( isset( $body['tag_name'] ) ) {
+										$latest_version = $body['tag_name'];
+									}
+								}
+							}
+
+							// Jämför versioner
+							$version_status = ( $version === $latest_version ) ? 'Up-to-date' : 'Outdated';
+
+							echo '<li><strong>' . esc_html( $package ) . '</strong> - Installed Version: ' . esc_html( $version ) . ' - Latest Version: ' . esc_html( $latest_version ) . ' (' . esc_html( $version_status ) . ')</li>';
 						}
 					}
 					echo '</ul>';

--- a/klarna-payments-for-woocommerce.php
+++ b/klarna-payments-for-woocommerce.php
@@ -494,3 +494,6 @@ if ( ! class_exists( 'WC_Klarna_Payments' ) ) {
 		return WC_Klarna_Payments::get_instance();
 	}
 }
+
+	// debug function for packages
+	require_once plugin_dir_path( __FILE__ ) . 'includes/show-packages.php';


### PR DESCRIPTION
This feature introduces an admin notice that provides an overview of the installed Krokedil packages and their version statuses. The functionality checks if an administrator is logged in and if a specific query parameter (show_packages) is present in the URL. When these conditions are met, version information is fetched from both the local packages and GitHub, enabling a direct comparison of the installed versions against the latest releases.

