### PR TITLE
Retrieves order from order-pay query

### DIFF
--- a/classes/class-kp-session.php
+++ b/classes/class-kp-session.php
@@ -214,11 +214,6 @@ class KP_Session {
 	 * @return WC_Order|null|WP_Error
 	 */
 	private function maybe_get_order( $order ) {
-		// If the order is already null, just return.
-		if ( null === $order ) {
-			return null;
-		}
-
 		// If we get passed a cart by the WooCommerce actions, then we treat that the same as null.
 		if ( is_a( $order, 'WC_Cart' ) ) {
 			return null;
@@ -229,13 +224,22 @@ class KP_Session {
 			return $order;
 		}
 
-		// Attempt to get the order from WooCommerce.
-		$tmp_order = wc_get_order( $order );
-		if ( ! $tmp_order ) {
+		if ( empty( $order ) ) {
+			// Since this set_session_data can be invoked with null whereas there is an order (see `html_client_token` func), we should check if we can retrieve the order ID from the query variable.
+			$order = absint( get_query_var( 'order-pay', 0 ) );
+		}
+
+		// If it is still null (or zero), we'll retrieve the session data from the existing checkout session.
+		if ( empty( $order ) ) {
+			return null;
+		}
+
+		$order = wc_get_order( $order );
+		if ( empty( $order ) ) {
 			return new WP_Error( 'kp_order_not_found', __( 'Order was not found', 'klarna-payments-for-woocommerce' ), $order );
 		}
 
-		return $tmp_order;
+		return $order;
 	}
 
 	/**


### PR DESCRIPTION
When resuming or creating a session, we'll check if we can receive the order from the query (i.e., order-pay) before we default to the existing checkout session, and finally creating a new one.

https://app.clickup.com/t/8698d6zjg