### PR TITLE
Restrict interoperability tokens to PSP partners

### DIFF
--- a/classes/class-kp-ajax.php
+++ b/classes/class-kp-ajax.php
@@ -252,6 +252,8 @@ if ( ! class_exists( 'KP_AJAX' ) ) {
 				wp_send_json_error( 'Failed to get unavailable features. Error messages: ' . implode( ', ', $unavailable_features['errors'] ) );
 			}
 
+			kp_set_is_psp_merchant( $unavailable_features['is_psp_merchant'] );
+
 			wp_send_json_success( $unavailable_features['feature_ids'] );
 		}
 

--- a/classes/class-kp-ajax.php
+++ b/classes/class-kp-ajax.php
@@ -249,6 +249,8 @@ if ( ! class_exists( 'KP_AJAX' ) ) {
 			$unavailable_features = kp_get_unavailable_feature_ids( $country_credentials );
 
 			if ( empty( $unavailable_features['feature_ids'] ) && ! empty( $unavailable_features['errors'] ) ) {
+				// If no unavailable features were found, the merchant should not be a PSP merchant.
+				kp_set_is_psp_merchant( false );
 				wp_send_json_error( 'Failed to get unavailable features. Error messages: ' . implode( ', ', $unavailable_features['errors'] ) );
 			}
 

--- a/classes/class-kp-assets.php
+++ b/classes/class-kp-assets.php
@@ -342,6 +342,11 @@ class KP_Assets {
 	 * @return void
 	 */
 	public function enqueue_interoperability_token() {
+		// Interoperability token should only be used for PSP merchants.
+		if ( ! get_option( 'kp_is_psp_merchant', false ) ) {
+			return;
+		}
+
 		wp_register_script(
 			'klarna_interoperability_token',
 			plugins_url( 'assets/js/klarna-interoperability-token.js', WC_KLARNA_PAYMENTS_MAIN_FILE ),

--- a/classes/class-kp-assets.php
+++ b/classes/class-kp-assets.php
@@ -343,7 +343,7 @@ class KP_Assets {
 	 */
 	public function enqueue_interoperability_token() {
 		// Interoperability token should only be used for PSP merchants.
-		if ( ! get_option( 'kp_is_psp_merchant', false ) ) {
+		if ( 'yes' !== get_option( 'kp_is_psp_merchant', 'no' ) ) {
 			return;
 		}
 

--- a/classes/class-kp-interoperability-token.php
+++ b/classes/class-kp-interoperability-token.php
@@ -14,6 +14,11 @@ class KP_Interoperability_Token {
 	 * @return void
 	 */
 	public function __construct() {
+		// Interoperability token should only be used for PSP merchants.
+		if ( ! get_option( 'kp_is_psp_merchant', false ) ) {
+			return;
+		}
+
 		// Clear the token from the session when they place an order.
 		add_action( 'woocommerce_checkout_order_processed', array( $this, 'clear_token' ) );
 		add_action( 'woocommerce_store_api_checkout_order_processed', array( $this, 'clear_token' ) );
@@ -55,7 +60,7 @@ class KP_Interoperability_Token {
 	 * @return void
 	 */
 	public function clear_token() {
-		if( null === WC()->session ) {
+		if ( null === WC()->session ) {
 			return;
 		}
 

--- a/classes/class-kp-interoperability-token.php
+++ b/classes/class-kp-interoperability-token.php
@@ -15,7 +15,7 @@ class KP_Interoperability_Token {
 	 */
 	public function __construct() {
 		// Interoperability token should only be used for PSP merchants.
-		if ( ! get_option( 'kp_is_psp_merchant', false ) ) {
+		if ( 'yes' !== get_option( 'kp_is_psp_merchant', 'no' ) ) {
 			return;
 		}
 

--- a/classes/class-kp-settings-saved.php
+++ b/classes/class-kp-settings-saved.php
@@ -120,6 +120,7 @@ class KP_Settings_Saved {
 			update_option( 'kp_unavailable_feature_ids', array() );
 		} else {
 			update_option( 'kp_unavailable_feature_ids', $unavailable_features['feature_ids'] ?? array() );
+			kp_set_is_psp_merchant( $unavailable_features['is_psp_merchant'] );
 		}
 	}
 

--- a/classes/class-wc-gateway-klarna-payments.php
+++ b/classes/class-wc-gateway-klarna-payments.php
@@ -272,6 +272,7 @@ class WC_Gateway_Klarna_Payments extends WC_Payment_Gateway {
 
 		$kp_unavailable_feature_ids = get_option( 'kp_unavailable_feature_ids', array() );
 		if ( in_array( 'general', $kp_unavailable_feature_ids ) ) {
+			kp_set_is_psp_merchant( true );
 			return false;
 		}
 

--- a/includes/kp-functions.php
+++ b/includes/kp-functions.php
@@ -411,10 +411,12 @@ function kp_get_unavailable_feature_ids( $country_credentials ) {
 			)
 		);
 	}
+	$unavailable_features = kp_map_unavailable_features( $collected_features );
 
 	return array(
-		'feature_ids' => kp_map_unavailable_features( $collected_features ),
-		'errors'      => $collected_errors,
+		'feature_ids'     => $unavailable_features,
+		'is_psp_merchant' => ! empty( $unavailable_features ) ?? false,
+		'errors'          => $collected_errors,
 	);
 }
 
@@ -482,8 +484,13 @@ function kp_map_unavailable_features( $collected_features ) {
 
 	// If KP is unavailable, we should also hide the Klarna Order Management feature.
 	if ( in_array( 'general', $unavailable_features, true ) ) {
+		kp_set_is_psp_merchant( true );
 		$unavailable_features[] = 'kom';
 	}
 
 	return $unavailable_features;
+}
+
+function kp_set_is_psp_merchant( $is_psp_merchant ) {
+	update_option( 'kp_is_psp_merchant', $is_psp_merchant ? 'yes' : 'no' );
 }

--- a/includes/kp-functions.php
+++ b/includes/kp-functions.php
@@ -415,7 +415,7 @@ function kp_get_unavailable_feature_ids( $country_credentials ) {
 
 	return array(
 		'feature_ids'     => $unavailable_features,
-		'is_psp_merchant' => ! empty( $unavailable_features ) ?? false,
+		'is_psp_merchant' => ! empty( $unavailable_features ) ? true : false,
 		'errors'          => $collected_errors,
 	);
 }


### PR DESCRIPTION
Restrict interoperability tokens exclusively to PSP sub-partners.