### PR TITLE
Add logic to hide settings if no valid keys are input

### DIFF
--- a/assets/css/klarna-payments-admin.css
+++ b/assets/css/klarna-payments-admin.css
@@ -401,7 +401,7 @@ div.kp_settings__section_content .kp_settings__content_gradient {
 	opacity: 1;
 }
 
-.kp_settings__section.unavailable, .kp_settings__section.invalid_credentials {
+.kp_settings__section.unavailable, .kp_settings__section.no_credentials {
 	display: none;
 }
 

--- a/assets/css/klarna-payments-admin.css
+++ b/assets/css/klarna-payments-admin.css
@@ -401,7 +401,7 @@ div.kp_settings__section_content .kp_settings__content_gradient {
 	opacity: 1;
 }
 
-.kp_settings__section.unavailable {
+.kp_settings__section.unavailable, .kp_settings__section.invalid_credentials {
 	display: none;
 }
 

--- a/classes/admin/class-kp-settings-page.php
+++ b/classes/admin/class-kp-settings-page.php
@@ -94,17 +94,18 @@ class KP_Settings_Page {
 	 */
 	public static function section_start_html( $section ) {
 		$kp_unavailable_feature_ids = get_option( 'kp_unavailable_feature_ids', array() );
-		$availability               = in_array( $section['id'], $kp_unavailable_feature_ids ) ? ' unavailable' : '';
 		$link_count                 = count( $section['links'] ?? array() );
-		$link_count        = count( $section['links'] ?? array() );
-		$setting_is_active = self::get_setting_status( $section['id'] );
-		$feature_status    = array(
+		$link_count                 = count( $section['links'] ?? array() );
+		$setting_is_active          = self::get_setting_status( $section['id'] );
+		$credentials_are_valid      = 'credentials' !== $section['id'] && 'no' === get_option( 'kp_has_valid_credentials' ) ? ' invalid_credentials' : '';
+		$feature_is_available       = in_array( $section['id'], $kp_unavailable_feature_ids ) ? ' unavailable' : '';
+		$feature_status             = array(
 			'class' => $setting_is_active ? ' active' : '',
 			'title' => $setting_is_active ? __( 'Active', 'klarna-payments-for-woocommerce' ) : __( 'Not active', 'klarna-payments-for-woocommerce' ),
 		);
 
 		?>
-		<div id="klarna-payments-settings-<?php echo esc_attr( $section['id'] ); ?>" class="kp_settings__section<?php echo esc_attr( $availability ); ?>">
+		<div id="klarna-payments-settings-<?php echo esc_attr( $section['id'] ); ?>" class="kp_settings__section<?php echo esc_attr( $feature_is_available . $credentials_are_valid ); ?>">
 			<div class="kp_settings__section_info">
 				<h3 class="kp_settings__section_title">
 					<?php echo esc_html( $section['title'] ); ?>

--- a/classes/admin/class-kp-settings-page.php
+++ b/classes/admin/class-kp-settings-page.php
@@ -97,7 +97,7 @@ class KP_Settings_Page {
 		$link_count                 = count( $section['links'] ?? array() );
 		$link_count                 = count( $section['links'] ?? array() );
 		$setting_is_active          = self::get_setting_status( $section['id'] );
-		$credentials_are_valid      = 'credentials' !== $section['id'] && 'no' === get_option( 'kp_has_valid_credentials' ) ? ' invalid_credentials' : '';
+		$credentials_are_valid      = 'credentials' !== $section['id'] && 'no' === get_option( 'kp_has_valid_credentials', 'no' ) ? ' invalid_credentials' : '';
 		$feature_is_available       = in_array( $section['id'], $kp_unavailable_feature_ids ) ? ' unavailable' : '';
 		$feature_status             = array(
 			'class' => $setting_is_active ? ' active' : '',

--- a/classes/admin/class-kp-settings-page.php
+++ b/classes/admin/class-kp-settings-page.php
@@ -97,7 +97,7 @@ class KP_Settings_Page {
 		$link_count                 = count( $section['links'] ?? array() );
 		$link_count                 = count( $section['links'] ?? array() );
 		$setting_is_active          = self::get_setting_status( $section['id'] );
-		$credentials_are_valid      = 'credentials' !== $section['id'] && 'no' === get_option( 'kp_has_valid_credentials', 'no' ) ? ' invalid_credentials' : '';
+		$has_credentials            = 'credentials' !== $section['id'] && ! kp_has_credentials() ? ' no_credentials' : '';
 		$feature_is_available       = in_array( $section['id'], $kp_unavailable_feature_ids ) ? ' unavailable' : '';
 		$feature_status             = array(
 			'class' => $setting_is_active ? ' active' : '',
@@ -105,7 +105,7 @@ class KP_Settings_Page {
 		);
 
 		?>
-		<div id="klarna-payments-settings-<?php echo esc_attr( $section['id'] ); ?>" class="kp_settings__section<?php echo esc_attr( $feature_is_available . $credentials_are_valid ); ?>">
+		<div id="klarna-payments-settings-<?php echo esc_attr( $section['id'] ); ?>" class="kp_settings__section<?php echo esc_attr( $feature_is_available . $has_credentials ); ?>">
 			<div class="kp_settings__section_info">
 				<h3 class="kp_settings__section_title">
 					<?php echo esc_html( $section['title'] ); ?>

--- a/includes/kp-functions.php
+++ b/includes/kp-functions.php
@@ -487,3 +487,31 @@ function kp_map_unavailable_features( $collected_features ) {
 
 	return $unavailable_features;
 }
+
+/**
+ * Checks if any Klarna Payments credentials are set in the settings.
+ *
+ * @return bool
+ */
+function kp_has_credentials() {
+	$settings = get_option( 'woocommerce_klarna_payments_settings', array() );
+
+	$merchant_ids   = array_filter(
+		$settings,
+		function ( $value, $key ) {
+			return str_contains( $key, 'merchant_id_' ) && ! empty( $value ) && ! is_array( $value ) && ! is_object( $value );
+		},
+		ARRAY_FILTER_USE_BOTH
+	);
+	$shared_secrets = array_filter(
+		$settings,
+		function ( $value, $key ) {
+			return str_contains( $key, 'shared_secret_' ) && ! empty(
+				$value
+			) && ! is_array( $value ) && ! is_object( $value );
+		},
+		ARRAY_FILTER_USE_BOTH
+	);
+
+	return ! empty( $merchant_ids ) && ! empty( $shared_secrets );
+}

--- a/includes/kp-functions.php
+++ b/includes/kp-functions.php
@@ -494,21 +494,20 @@ function kp_map_unavailable_features( $collected_features ) {
  * @return bool
  */
 function kp_has_credentials() {
-	$settings = get_option( 'woocommerce_klarna_payments_settings', array() );
+	$settings  = get_option( 'woocommerce_klarna_payments_settings', array() );
+	$test_mode = 'yes' === ( $settings['testmode'] ?? 'no' ) ? 'test_' : '';
 
 	$merchant_ids   = array_filter(
 		$settings,
-		function ( $value, $key ) {
-			return str_contains( $key, 'merchant_id_' ) && ! empty( $value ) && ! is_array( $value ) && ! is_object( $value );
+		function ( $value, $key ) use ( $test_mode ) {
+			return str_starts_with( $key, $test_mode . 'merchant_id_' ) && ! empty( $value ) && ! is_array( $value ) && ! is_object( $value );
 		},
 		ARRAY_FILTER_USE_BOTH
 	);
 	$shared_secrets = array_filter(
 		$settings,
-		function ( $value, $key ) {
-			return str_contains( $key, 'shared_secret_' ) && ! empty(
-				$value
-			) && ! is_array( $value ) && ! is_object( $value );
+		function ( $value, $key ) use ( $test_mode ) {
+			return str_starts_with( $key, $test_mode . 'shared_secret_' ) && ! empty( $value ) && ! is_array( $value ) && ! is_object( $value );
 		},
 		ARRAY_FILTER_USE_BOTH
 	);


### PR DESCRIPTION
Hide all settings outside of the "Credentials" section, if no valid credentials are input and saved.