### PR TITLE
add changelog.txt

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,974 +1,581 @@
 *** Klarna for WooCommerce Changelog ***
 
-= 3.0.6 - 2025-05-27 =
-* Enhancement - Implement 3D secure check for Google Pay #3163
-* Enhancement - Add options for "Disable Credit Cards" and "Language" #3226
-* Enhancement - Improve the loading experience for the new UI #3269
-* Enhancement - Enhance the accessibility of the new Settings UI #3294
-* Enhancement - Add capture pre-conditions for card payment source #3300
-* Enhancement - Enable all/Disable all toggle next to Alternative Payment methods on Payment Methods tab #3321
-* Enhancement - Add installment notifications for Mexico store locations #3404, #3405
-* Fix - Various issues for Mexico store locations during onboarding & plugin configuration #3403
-* Fix - APFS plugin triggers incorrect renewal date for simple products as subscriptions #3272
-* Fix - PayPal Smart Button incompatible with WooCommerce Subscription Switching #3291
-* Fix - Fastlane gateway visible on Pay for Order page #3293
-* Fix - Pay Later Messaging configurator preview alignment #3305
-* Fix - Product editing screen for variable products unresponsive (PayPal Subscriptions API error) #3311
-* Fix - Update selector for hiding express checkout #3318
-* Fix - 'Ignoring unknown key' console warnings when modifying payment gateway state #3322
-* Fix - Ratepay Payment Option Not Available for Unassembled Product Bundles #3325
-* Fix - "Disable Specific credit cards" shows "Select" as a possible value #3342
-* Fix - Stripe not visible at checkout when PayPal Subscriptions API is enabled #3343
-* Fix - Ensure correct ACDC behavior for non-ACDC countries (e.g., Vietnam) #3351
-* Fix - ACDC payments for Subscriptions failing at checkout for new users #3355
-* Fix - BCDC not enabled by default when cards selected during onboarding #3366
-* Fix - Block checkout - Address form missing after payment on Product and Cart pages #3371
-* Fix - Payments with Debit & Credit Cards failing #3376
-* Fix - PayPalGateway::process_payment on completed order leads to order failure #3374
-* Fix - New settings UI background color impacted by WooCommerce 9.9+ #3407
-* Fix - Can not save payments if subscriptions is not selected when onboarding #3408
-
-= 3.0.5 - 2025-04-23 =
-* Fix - Onboarding screen blank when WooPayments plugin is active #3312
-
-= 3.0.3 - 2025-04-08 =
-* Fix - BN code was set before the installation path was initialized #3309
-* Fix - Things to do next referenced Apple Pay while in branded-only mode #3308
-* Fix - Disabled payment methods were not hidden in reactified WooCommerce Payments settings tab #3290
-
-= 3.0.2 - 2025-04-03 =
-* Enhancement - Check the branded-only flag when settings-UI is loaded the first time #3278
-* Enhancement - Implement a Cache-Flush API #3276
-* Enhancement - Disable the mini-cart location by default #3284
-* Enhancement - Remove branded-only flag when uninstalling PayPal Payments #3295
-* Fix - Welcome screen lists "all major credit/debit cards, Apple Pay, Google Pay," in branded-only mode #3281
-* Fix - Correct heading in onboarding step 4 in branded-only mode #3282
-* Fix - Hide the payment methods screen for personal user in branded-only mode #3286
-* Fix - Enabling Save PayPal does not disable Pay Later messaging #3288
-* Fix - Settings UI: Fix Feature button links #3285
-* Fix - Create mapping for the 3d_secure_contingency setting #3262
-* Fix - Enable Fastlane Watermark by default in new settings UI #3296
-* Fix - Payment method screen is referencing credit cards, digital wallets in branded-only mode #3297
-
-= 3.0.1 - 2025-03-26 =
-* Enhancement - Include Fastlane meta on homepage #3151
-* Enhancement - Include Branded-only plugin configuration for certain installation paths
-* Enhancement - Include UI status in system report #3248
-* Enhancement - Minor enhancements in new UI scrolling & highlighting behavior #3240
-* Fix - "Warning: Class 'WooCommerce\PayPalCommerce\Vendor\Stringable' not found" after 3.0.0 update #3235
-* Fix - ACDC does not work on the Classic Checkout when using the new UI #3219
-* Fix - "Send only" country banner not displayed in the new UI #3236
-* Fix - Typo in welcome screen #3258
-* Fix - onboarding.js file from old UI enqueued in new UI #3263
-* Fix - Onboarding in new UI with personal account does not hide all ineligible features #3254
-* Fix - ACDC not defaulting on for eligible merchants after onboarding with Expanded Checkout selection #3250
-* Fix - “Failed to fetch onboarding URL” error when onboarding with Subscriptions selected from non-Vault region #3242
-* Fix - Fastlane SDK token requested when Fastlane is disabled #3009
-* Fix - Subscription renewal payment via ACDC may fail in some cases due to 3D Secure #3098
-* Fix - Error: _load_textdomain_just_in_time Called Incorrectly when running docker compose #3172
-* Fix - Shipping callback not loading for guest users in some scenarios #3169
-* Fix - Phone number not saved in WC order when using Pay Now experience #3160
-* Fix - Phone number not pre-populated on Checkout block in continuation mode #3160
-* Fix - "Unfortunately, your credit card details are not valid" shown with actually valid card during checkout with invalid postcode. #3067
-* Fix - Incorrect Subscription Cancellation Handling with PayPal Subscriptions #3046
-* Tweak - Added PayPal as contributor #3259
-
-= 3.0.0 - 2025-03-17 =
-* Enhancement - Redesigned settings UI for new users #2908
-* Enhancement - Enable Fastlane by default on new store setups when eligible #3199
-* Enhancement - Enable support for advanced card payments and features for Hong Kong & Singapore #3089
-* Fix - Dependency conflict with more recent psr/log versions on PHP8+ #2993
-* Fix - PayPal Checkout Gateway subscription migration layer not renewing subscriptions #2699
-* Fix - Fatal error when gateway settings initialized too early by third-party plugin #2766
-* Fix - Next Payment date for Subscriptions not updating when processing a PayPal Subscriptions renewal order #2959
-* Fix - Changing the subscription payment method to ACDC triggers error #2891
-* Fix - Standard Card button not appearing in standalone gateway for free trial subscription products #2935
-* Fix - Validation error when using Trustly payment method #3031
-* Fix - Error in continuation mode due to wrong gateway selection on Checkout block #2996
-* Fix - Error in error in PayLaterConfigurator #2989
-* Tweak - Removed currency requirement for Vault v3 #2919
-* Tweak - Update plugin author from WooCommerce to PayPal
-
-= 2.9.6 - 2025-01-06 =
-* Fix - NOT_ENABLED_TO_VAULT_PAYMENT_SOURCE on PayPal transactions when using ACDC Vaulting without PayPal Vault approval #2955
-* Fix - Express buttons for Free Trial Subscription products on Block Cart/Checkout trigger CANNOT_BE_ZERO_OR_NEGATIVE error #2872
-* Fix - String translations not applied to Card Fields on Block Checkout #2934
-* Fix - Fastlane component included in script when Fastlane is disabled #2911
-* Fix - Zero amount line items may trigger CANNOT_BE_ZERO_OR_NEGATIVE error after rounding error #2906
-* Fix - “Save changes” is grey and unclickable when switching from Sandbox to Live #2895
-* Fix - plugin queries variations when button/messaging is disabled on single product page #2896
-* Fix - Use get_id instead of get_order_number on setting custom_id (author @0verscore) #2930
-* Enhancement - Improve fraud response order notes for Advanced Card Processing transactions #2905
-* Tweak - Update the minimum plugin requirements to WordPress 6.5 & WooCommerce 9.2 #2920
-
-= 2.9.5 - 2024-12-10 =
-* Fix - Early translation loading triggers `Function _load_textdomain_just_in_time was called incorrectly.` notice #2816
-* Fix - ACDC card fields not loading and payment not successful when Classic Checkout Smart Button Location disabled #2852
-* Fix - ACDC gateway does not appear for guests when is Fastlane enabled and a subscription product is in the cart #2745
-* Fix - "Voide authorization" button does not appear for Apple Pay/Google Pay orders when payment buttons are separated #2752
-* Fix - Additional payment tokens saved with new customer_id #2820
-* Fix - Vaulted payment method may not be displayed in PayPal button for return buyer #2809
-* Fix - Conflict with EasyShip plugin due to shipping methods loading too early #2845
-* Fix - Restore accidentally removed ACDC currencies #2838
-* Enhancement - Native gateway icon for PayPal & Pay upon Invoice gateways #2712
-* Enhancement - Allow disabling specific card types for Fastlane #2704
-* Enhancement - Fastlane Insights SDK implementation for block Checkout #2737
-* Enhancement - Hide split local APMs in Payments settings tab when PayPal is not enabled #2703
-* Enhancement - Do not load split local APMs on Checkout when PayPal is not enabled #2792
-* Enhancement - Add support for Button Options in the Block Checkout for Apple Pay & Google Pay buttons #2797 #2772
-* Enhancement - Disable “Add payment method” button while saving ACDC payment #2794
-* Enhancement - Sanitize soft_descriptor field #2846 #2854
-
-= 2.9.4 - 2024-11-11 =
-* Fix - Apple Pay button preview missing in Standard payment and Advanced Processing tabs #2755
-* Fix - Set "Sold individually" only for subscription connected to PayPal #2710
-* Fix - Ensure Google Pay button does not appear for subscriptions #2718
-* Fix - PayPal Subscriptions API renewal order not created in WooCommerce #2612
-* Fix - Apple Pay button disappears on Classic Checkout #2722
-* Fix - Google Pay and Apple Pay as separate gateways does not show button when checkout remove from button locations #2756
-* Fix - Add GW refund support for Apple Pay #2746
-* Fix - PayPal Subscriptions cancel and suspend from Subscriptions list page does not work #2632
-* Fix - Displaying of HTML tags in product title on choosing a product for tracking (2801) #2701
-* Fix - Payment with OXXO cause continuation state for next payment #2702
-* Fix - Fix problems with autoptimize plugin #2705
-* Fix - Missing custom field PayPal Transaction Fee for OXXO #2700
-* Enhancement - Add void button #2678
-* Enhancement - Use basic redirect gateway when checkout smart buttons disabled #2714
-* Enhancement - Receive button properties from the Checkout Block #2448
-* Enhancement - Run PPEC\DeactivateNote query only in backend #2719
-* Enhancement - Prevent plugin use for "Send only" countries #2721
-* Enhancement - Do not add pay later button in editor #2570
-* Enhancement - Axo: Remove the submit button when Fastlane is disabled #2720
-* Enhancement - Sync the PayPal product page button state to Apple/Google Pay buttons, show alerts #2742
-
-= 2.9.3 - 2024-10-15 =
-* Fix - Multi-currency support #2667
-* Fix - "0.00" amount in Google Pay for virtual products #2636
-* Fix - Unsuccessfully payment from product page with Apple Pay button #2643
-* Fix - Button Unlinking PayPal Subscriptions plan does not showing for simple subscription #2618
-* Fix - Declare tokenization for ACDC only when vaulting enabled #2581
-* Fix - Classic shortcode block type checks #2608
-* Fix - PUI error in editor #2580
-* Fix - Add a new namespaced script loader for ApplePay #2682 #2675
-* Fix - Axo Block: Fix the Fastlane modal info message text overflow issue #2663
-* Fix - Add Custom Placeholder Handling when rendering the card fields #2651
-* Fix - Use the PayPal icons instead of WC ones #2639
-* Fix - Google Pay preview config and style #2661
-* Fix - Improve context detection #2631
-* Fix - Check that get_the_ID is valid before using #2573
-* Fix - Axo Block: Always display the Fastlane watermark in the includeAdditionalInfo mode #2690
-* Fix - Axo Block: Display card fields for authenticated cardless profiles #2672
-* Fix - Google Pay: Fix button preview in the editor #2688
-* Fix - ACDC gateway not visible on the block Checkout for logged-out users #2693
-* Enhancement - Enhancement - Add Fastlane support for Checkout block
-* Enhancement - Multiple calls to POST /v1/oauth2/token?grant_type=client_credentials&response_type=id_token #2671
-* Enhancement - Fastlane update shipping options & taxes when changing address #2665
-* Enhancement - Axo: Remove Axo from the Checkout block in the editor and add an ACDC card preview #2662
-* Enhancement - Set email when creating order for express payment #2577
-
-= 2.9.2 - 2024-10-01 =
-* Enhancement - Add Fastlane support for Classic Checkout
-* Fix - Fatal error when Pay Later messaging configurator was disabled with a code snippet
-
-= 2.9.1 - 2024-09-24 =
-* Fix - Improve card fields hiding #2574
-* Fix - Google Pay: Shipping callback not calculating totals correctly on Single Product page #2513
-* Fix - Fix shipping callback condition in status report #2578
-* Fix - Can't Disconnect Account #2539
-* Fix - Google Pay billing data without shipping callback #2525
-* Fix - Standard payment tab - Google Pay and Apple Pay button - Shape from one location is applied to all until saving changes #2419
-* Enhancement - Allow to override the list of Pay Later supported countries #2563
-* Enhancement - Add more feature statuses into system report #2550
-* Enhancement - Use SVG for APM gateway icons #2509
-* Enhancement - Add inline notice to inform users about ACDC block Checkout support if the store uses a Classic Checkout setup #2422
-* Enhancement - Remove leftover console.log #2589
-* Enhancement - Require PHP 7.4+, WP 6.3+, WC 6.9+ #2556
-* Enhancement - Modularity module migration #1944
-* Enhancement - Keep only 5 tags in readme.txt #2562
-* Enhancement - Select ACDC by default during onboarding for China store locations #2619
-* Enhancement - Add title, description and gatewayId to the express payment method #2566
-
-= 2.9.0 - 2024-09-02 =
-* Fix - Fatal error in Block Editor when using WooCommerce blocks #2534
-* Fix - Can't pay from block pages when the shipping callback is enabled and no shipping methods defined #2429
-* Fix - Various Google Pay button fixes #2496
-* Fix - Buying a free trial subscription with ACDC results in a $1 charge in the API call #2465
-* Fix - Problem with Google Pay and Apple Pay button placement on Pay for Order page #2542
-* Fix - When there isn't any shipping option for the address the order is still created from classic cart #2437
-* Fix - Patch the order with no shipping methods, instead of throwing an error #2435
-* Enhancement - Separate Apple Pay button for Classic Checkout #2457
-* Enhancement - Remove AMEX support for ACDC when store location is set to China #2526
-* Enhancement - Inform users of Pay Later messaging configuration when Pay Later wasn't recently enabled #2529
-* Enhancement - Update ACDC signup URLs #2475
-* Enhancement - Implement country based APMs via Orders API #2511
-* Enhancement - Update PaymentsStatusHandlingTrait.php (author @callmeahmedr) #2523
-* Enhancement - Disable PayPal Shipping callback by default #2527
-* Enhancement - Change Apple Pay and Google Pay default button labels to plain #2476
-* Enhancement - Add Package Tracking compatibility with DHL Shipping plugin #2463
-* Enhancement - Add support for WC Bookings when skipping checkout confirmation #2452
-* Enhancement - Remove currencies from country-currency matrix in card fields module #2441
-
-= 2.8.3 - 2024-08-12 =
-* Fix - Google Pay: Prevent field validation from being triggered on checkout page load #2474
-* Fix - Do not add tax info into order meta during order creation #2471
-* Fix - PayPal declares subscription support when for Subscription mode is set Disable PayPal for subscription #2425
-* Fix - PayPal js files loaded on non PayPal pages #2411
-* Fix - Google Pay: Fix the incorrect popup triggering #2414
-* Fix - Add tax configurator when programmatically creating WC orders #2431
-* Fix - Shipping callback compatibility with WC Name Your Price plugin #2402
-* Fix - Uncaught Error: Cannot use object of type ...\Settings as array in .../AbstractPaymentMethodType.php (3253) #2334
-* Fix - Prevent displaying smart button multiple times on variable product page #2420
-* Fix - Prevent enabling Standard Card Button when ACDC is enabled #2404
-* Fix - Use client credentials for user tokens #2491
-* Fix - Apple Pay: Fix the shipping callback #2492
-* Enhancement - Separate Google Pay button for Classic Checkout #2430
-* Enhancement - Add Apple Pay and Google Pay support for China, simplify country-currency matrix #2468
-* Enhancement - Add AMEX support for Advanced Card Processing in China #2469
-
-= 2.8.2 - 2024-07-22 =
-* Fix - Sold individually checkbox automatically disabled after adding product to the cart more than once #2415
-* Fix - All products "Sold individually" when PayPal Subscriptions selected as Subscriptions Mode #2400
-* Fix - W3 Total Cache: Remove type from file parameter as sometimes null gets passed causing errors #2403
-* Fix - Shipping methods during callback not updated correctly #2421
-* Fix - Preserve subscription renewal processing when switching Subscriptions Mode or disabling gateway #2394
-* Fix - Remove shipping callback for Venmo express button #2374
-* Fix - Google Pay: Fix issue with data.paymentSource being undefined #2390
-* Fix - Loading of non-Order as a WC_Order causes warnings and potential data corruption #2343
-* Fix - Apple Pay and Google Pay buttons don't appear in PayPal Button stack on multi-step Checkout #2372
-* Fix - Apple Pay: Fix when shipping is disabled #2391
-* Fix - Wrong string in smart button preview on Standard Payments tab #2409
-* Fix - Don't break orders screen when there is an exception for package tracking #2369
-* Fix - Pay Later button preview is missing #2371
-* Fix - Apple Pay button layout #2367
-* Enhancement - Remove BCDC button from block Express Checkout area #2381
-* Enhancement - Extend Advanced Card Processing country eligibility for China #2397
-
-= 2.8.1 - 2024-07-01 =
-* Fix - Don't render tracking metabox if PayPal order does not belong to connected merchant #2360
-* Fix - Fatal error when the ppcp-paylater-configurator module is disabled via code snippet #2327
-* Fix - Apple Pay & Google Pay buttons no longer visible in Standard Payments button previews after moving the configuration to Advanced Card Processing tab #2325
-* Fix - Fix Smart Buttons on Elementor checkout widget #2284
-* Fix - Pay by link - Capturing order from guest user causing fatal error when Vaulting is enabled #2382
-* Fix - Enable the gateway settings JS file on connection tab #2377
-* Enhancement - Add filter for certain settings to allow gateway translation e.g. via WPML #2308
-* Enhancement - Filter for adding more contexts in can_render_dcc checker #2346
-* Enhancement - Do not request id_token for guest users #2283
-* Enhancement - Prevent multiple PayPal Subscription products in the cart if PayPal Subscription API is active #2320
-* Enhancement - Prevent script caching & minification from Litespeed Cache and W3 Total Cache plugins #2316
-* Enhancement - Remove Giropay references due to deprecation #2379
-
-= 2.8.0 - 2024-06-11 =
-* Fix - Calculate totals after adding shipping to include taxes #2296
-* Fix - Package tracking integration throws error in 2.7.1 #2289
-* Fix - Make PayPal Subscription products unique in cart #2265
-* Fix - PayPal declares subscription support when merchant not enabled for Reference Transactions #2282
-* Fix - Google Pay and Apple Pay Settings button from Connection tab have wrong links #2273
-* Fix - Smart Buttons in Block Checkout not respecting the location setting (2830) #2278
-* Fix - Disable Pay Upon Invoice if billing/shipping country not set #2281
-* Fix - Critical error on pay for order page when we try to pay with ACDC gateway #2321
-* Enhancement - Enable shipping callback for WC subscriptions #2259
-* Enhancement - Disable the shipping callback for "venmo" when vaulting is active #2269
-* Enhancement - Improve "Could not retrieve order" error message #2271
-* Enhancement - Add block Checkout compatibility to Advanced Card Processing #2246
-
-= 2.7.1 - 2024-05-28 =
-* Fix - Ensure package tracking data is sent to original PayPal transaction #2180
-* Fix - Set the 'Woo_PPCP' as a default value for data-partner-attribution-id #2188
-* Fix - Allow PUI Gateway for refund processor #2192
-* Fix - Notice on newly created block cart checkout #2211
-* Fix - Apple Pay button in the editor #2177
-* Fix - Allow shipping callback and skipping confirmation page from any express button #2236
-* Fix - Pay Later messaging configurator sometimes displays old settings after saving #2249
-* Fix - Update the apple-developer-merchantid-domain-association validation strings for Apple Pay #2251
-* Fix - Enable the Shipping Callback handlers #2266
-* Enhancement - Use admin theme color #1602
-
-= 2.7.0 - 2024-04-30 =
-* Fix - Zero sum subscriptions cause CANNOT_BE_ZERO_OR_NEGATIVE when using Vault v3 #2152
-* Fix - Incorrect Pricing Issue with Variable Subscriptions in PayPal Subscriptions Mode #2156
-* Fix - Wrong return_url in multisite setup when using subdomains #2157
-* Fix - Fix the fundingSource is not defined error on Block Checkout #2185
-* Enhancement - Add the data-page-type attribute for JS SDK #2161
-* Enhancement - Save Card Last Digits in order meta for Advanced Card Payments #2149
-* Enhancement - Refactor the Pay Later Messaging block and add dedicated Cart/Checkout blocks #2153
-* Enhancement - "Next Payment" status not updated when using PayPal Subscriptions #2091
-* Enhancement - Optimize default settings for new store configurations #2158
-* Enhancement - Improve tooltip information for tagline #2154
-* Enhancement - Improve error message on certain exceptions #1354
-* Enhancement - Cart Pay Later block: Change the default insert position #2179
-* Enhancement - Messages Bootstrap: Add a render retry functionality #2181
-
-= 2.6.1 - 2024-04-09 =
-* Fix - Payment tokens fixes and adjustments #2106
-* Fix - Pay upon Invoice: Add input validation to Experience Context fields #2092
-* Fix - Disable markup in get_plugin_data() returns to fix an issue with wptexturize() #2094
-* Fix - Problem changing the shipping option in block pages #2142
-* Fix - Saved payment token deleted after payment with another saved payment token #2146
-* Enhancement - Pay later messaging configurator improvements #2107
-* Enhancement - Replace the middleware URL from connect.woocommerce.com to api.woocommerce.com/integrations #2130
-* Enhancement - Remove all Sofort references as it has been deprecated #2124
-* Enhancement - Improve funding source names #2118
-* Enhancement - More fraud prevention capabilities by storing additional data in the order #2125
-* Enhancement - Update ACDC currency eligibility for AMEX #2129
-* Enhancement - Sync shipping options with Venmo when skipping final confirmation on Checkout #2108
-* Enhancement - Card Fields: Add a filter for the CVC field and update the placeholder to match the label #2089
-* Enhancement - Product Title: Sanitize before sending to PayPal #2090
-* Enhancement - Add filter for disabling permit_multiple_payment_tokens vault attribute #2136
-* Enhancement - Filter to hide PayPal email address not working on order detail #2137
-
-= 2.6.0 - 2024-03-20 =
-* Fix - invoice_id not included in API call when creating payment with saved card #2086
-* Fix - Typo in SCA indicators for ACDC Vault transactions #2083
-* Fix - Payments with saved card tokens use Capture intent when Authorize is configured #2069
-* Fix - WooPayments multi-currency causing currency mismatch error on Block Cart & Checkout pages #2054
-* Fix - "Must pass createSubscription with intent=subscription" error with PayPal Subscriptions mode #2058
-* Fix - "Proceed to PayPal" button displayed for Free trial PayPal Subscription products when payment token is saved #2041
-* Fix - ACDC payments with new credit card may fail when debugging is enabled (JSON malformed by warning) #2051
-* Enhancement - Add Pay Later Messaging block #1897
-* Enhancement - Submit the form instead of refreshing the page to show the save notice #2081
-* Enhancement - Integrate pay later messaging block with the messaging configurator #2080
-* Enhancement - Reauthorize authorized payments #2062
-* Enhancement - Do not handle VAULT.PAYMENT-TOKEN.CREATED webhook for Vault v3 #2079
-* Enhancement - Improve the messaging configurator styles #2053
-* Enhancement - Ensure PayPal Vaulting is not selected as Subscriptions Mode when Reference Transactions are disabled #2057
-* Enhancement - Pay later messaging configurator & messaging block adjustments #2096
-
-= 2.5.4 - 2024-02-27 =
-* Fix - Cannot enable Apple Pay when API credentials were manually created #2015
-* Fix - Cart simulation type error #1943
-* Enhancement - Apple Pay recurring payments #1986
-* Enhancement - Real Time Account Updater (RTAU) integration #2027
-* Enhancement - Prepare the SKU for sending to PayPal #2033
-* Enhancement - Store the Card Brand in Address Verification Result instead of 3DS authentication result #2026
-* Enhancement - Update country eligibility for AdvancedCard Processing, Apple Pay, Google Pay #2019
-* Enhancement - Disable PayPal Vaulting setting instead of hiding it when Reference Transactions not available #2029
-* Enhancement - Store three d secure enrollment status and authentication status responses in wc order #1980
-* Enhancement - Add more checks to prevent "PayPal order ID not found" errors #2038
-* Enhancement - Disable messaging configurator when vault is enabled #2042
-* Feature preview - Pay Later Messaging configurator #1924
-
-= 2.5.3 - 2024-02-06 =
-* Fix - Free trial subscription products using PayPal Vaulting when PayPal Subscriptions configured as Subscriptions Mode #1979
-* Fix - Pay by link - Germany - PayPal buttons are not visible on Pay for order page #2014
-* Enhancement - Extend Apple Pay, Google Pay, Vault v3 (& RTAU) country availability #1992
-* Enhancement - Enable card fields for ACDC and Vault v3 supported countries/currencies #2007
-* Enhancement - Update ACDC supported currencies list #1991
-* Enhancement - Check if the $wpdb->wc_orders exists before query #1996
-* Enhancement - Remove MercadoPago from disable funding sources #2003
-* Enhancement - Improve onboarding notice text #2002
-
-= 2.5.2 - 2024-02-01 =
-* Fix - NOT_ENABLED_TO_VAULT_PAYMENT_SOURCE error for merchants without reference transactions #1984
-* Fix - Fatal error in WooCommerce PayPal Payments plugin after 2.5.0 update #1985
-* Fix - Can not refund order purchased with Vault v3 Card payment #1997
-* Fix - PayPal Vaulting Subscriptions mode setting visible when merchant not enabled for Reference Transactions #1999
-* Fix - card-fields parameter included in button script despite Advanced Card Processing disabled #2005
-* Enhancement - Add setup URL for reference transactions #1964
-* Enhancement - Improve PUI performance for variable products #1950
-
-= 2.5.1 - 2024-01-24 =
-* Temporary revert Vaulting integration changes introduced in 2.5.0
-
-= 2.5.0 - 2024-01-22 =
-* Fix - WC Subscriptions change subscription payment #1953
-* Fix - GooglePay and ApplePay buttons disappear from the minicart when adding a product to the cart on the shop page #1915
-* Enhancement - Enable Vault v3 and Card Fields by default for US merchants #1967
-* Enhancement - Vault v3 WC Subscriptions integration #1920
-* Enhancement - Implement early WC validation for Hosted Card Fields #1925
-* Enhancement - Rename button locations #1946
-* Enhancement - Improve Apple Pay validation notice text #1938
-* Enhancement - Improve feature availability check UX #1941
-* Enhancement - Make all hosted card fields strings translatable #1926
-* Enhancement - PHP 8.2 deprecations #1939
-* Enhancement - Subscription support on Block Cart & Block Express Checkout #1956
-* Enhancement - Venmo Vaulting integration #1958
-* Enhancement - Add package tracking support for UK #1970
-
-= 2.4.3 - 2024-01-04 =
-* Fix - PayPal Subscription initiated without a WooCommerce order #1907
-* Fix - Block Checkout reloads when submitting order with empty fields #1904
-* Fix - "Send checkout billing and shipping data to Apple Pay" displayed when Apple Pay is disabled #1883
-* Fix - "Order does not contain intent" error for ACDC renewals when triggering 3D Secure #1888
-* Fix - PayPal Subscriptions button greyed out (inactive) on Checkout page for variable subscription products #1914
-* Enhancement - Add button to reload feature eligibility status from Connection tab #1902
-* Enhancement - Apple Pay validation message improvements #1901
-* Enhancement - Improve support for Classic Cart & Classic Checkout blocks #1894
-* Enhancement - Ensure uniform button appearance for PayPal, Google Pay, and Apple Pay buttons #1900
-* Enhancement - remove string translations for package tracking carriers from repository #1885
-* Enhancement - Incorrect margins when PayPal buttons are rendered as separate gateways. #1908
-* Enhancement - Improved button spacing when Apple Pay is enabled but current buyer is not eligible #1922
-* Feature preview - Save payment methods (Vault v3) integration  #1779
-
-= 2.4.2 - 2023-12-04 =
-* Fix - Action callback arguments count in ShipStation tracking integration #1841
-* Fix - Google Pay scripts loading on unrelated admin pages #1834
-* Fix - Do not ignore disabled APMs list in blocks #1865
-* Fix - Display Package Tracking metabox below Order actions when HPOS is active #1850
-* Fix - ApplePay use checkout form data to update shipping and billing #1832
-* Fix - Fix Apple Pay CSS #1872
-* Enhancement - Allow redirect to PayPal with "Place order" button if smart buttons failed to load #1840 #1870
-* Enhancement - Extend list of supported countries for Package Tracking v2 integration #1848
-* Enhancement - Improve Block Theme support for Pay Later messaging #1855
-* Enhancement - Render block buttons separately and add block style settings #1858
-* Enhancement - Enable Block Cart and Block Express Checkout button locations by default #1852
-* Enhancement - Improve single product page button placement with Block themes #1847
-* Enhancement - Remove the Home location from default enabled Pay Later messaging locations #1856
-* Enhancement - Chrome browser detected as eligible for Apple Pay on settings page #1828
-* Enhancement - Hide Apple Pay & Google Pay for subscription type products #1835
-* Enhancement - Add Standard Card Button gateway styling settings & preview #1827
-* Feature preview - Upgrade to new Hosted Card Fields for Advanced Card Processing #1843
-
-= 2.4.1 - 2023-11-14 =
-* Fix - Error "PayPal order ID not found in meta" prevents automations from triggering when buying subscription via third-party payment gateway #1822
-* Fix - Card button subscription support declaration #1796
-* Fix - Pay Later messaging disappears when updating shipping option on cart page #1807
-* Fix - Apple Pay payment from single product may fail after changing shipping options in Apple Pay payment sheet #1810
-* Enhancement - Extend list of supported countries for Advanced Card Processing #1808
-* Enhancement - Extend Apple Pay/Google Pay country eligibility to Italy #1811
-* Enhancement - Override language used to display PayPal buttons #600
-* Enhancement - Apple Pay button preview #1824
-* Enhancement - Add Apple Pay & Google Pay logos on the onboarding page #1823
-* Enhancement - Improve Apple Pay compatibility with variable products on single product page #1803
-* Enhancement - Apple Pay domain registration & browser eligibility check #1821
-* Enhancement - Package Tracking compatibility with WooCommerce Shipping & ShipStation for WooCommerce #1813
-* Enhancement - Fill form when continuation in block #1794
-* Enhancement - Display Shop location Pay Later messaging on product category pages #1809
-* Enhancement - Present apple-developer-merchantid-domain-association file only when Apple Pay is enabled #1818
-* Enhancement - Improve Apple Pay compatibility on Pay for Order page #1815
-* Enhancement - Display Pay Later messages before the payment methods on the Pay for Order page #1814
-* Enhancement - Handle undefined array key warnings on PHP 8.1 #1804
-
-= 2.4.0 - 2023-10-31 =
-* Fix - Mini-Cart Bug cause of wrong DOM-Structure in v2.3.1 #1735
-* Fix - ACDC disappearing after plugin updates #1751
-* Fix - Subscription module hooks #1748
-* Fix - Ensure PayPal Subscriptions API products description is 1-127 characters #1738
-* Fix - Add validation on the Plan Name field to not accept a blank value #1754
-* Enhancement - Improve Pay Later messages and add Shop, Home locations #1770
-* Enhancement - Use api-m PayPal API URLs #1740
-* Enhancement - Google Pay Settings improvements #1719
-* Enhancement - Apple Pay transaction improvements #1767
-* Enhancement - Change default ACDC title #1750
-* Enhancement - Cart simulation improvements #1753
-* Enhancement - Billing schedule fields not greyed out when PayPal Subscriptions product is connected #1755
-* Enhancement - Check validation errors when submitting in block #1528
-* Enhancement - Improve handling of server error when submitting block #1785
-* Enhancement - Extend Apple Pay country eligibility #1781
-* Enhancement - Apple Pay validation notice improvements #1783
-* Enhancement - Apple Pay payment process issues #1789
-* Enhancement - Disable the tracking if payment is not captured #1780
-* Enhancement - Place order button remains - Could not retrieve order #1786
-* Enhancement - Google Pay for variable product greyed out but clickable #1788
-* Enhancement - Merchant credential validation & remove PAYEE object #1795
-
-= 2.3.1 - 2023-09-26 =
-* Fix - Fatal error when saving product while WooCommerce Subscriptions plugin is not active #1731
-* Fix - Validate tracking data only for add/update Package Tracking #1729
-* Fix - Disable Package Tracking for order if transaction ID doesn't exist #1727
-
-= 2.3.0 - 2023-09-26 =
-* Fix - Plus sign in PayPal account email address gets converted to space #771
-* Fix - Payment method dropdown option label on edit order screen for ppcp-gateway option displaying wrong name #1639
-* Fix - WooCommerce Bookings products don't remain in Cart as a guest when PayPal button active on single product #1645
-* Fix - Since version > 2.2.0 the PayPal Checkout button on single product pages does not redirect anymore #1664
-* Fix - PayPal fee and PayPal Payout do not change on order if we do partial refund #1578
-* Fix - Order does not contain intent error when using ACDC payment token while buyer is not present #1506
-* Fix - Error when product description linked with a PayPal subscription exceeds 127 characters #1700
-* Fix - $_POST uses the wrong key to hold the shipping method #1652
-* Fix - WC Payment Token created multiple times when webhook is received #1663
-* Fix - Subtotal mismatch line name shows on Account settings page when merchant is disconnected #1702
-* Fix - Warning prevents payments on Pay for Order page when debugging is enabled #1703
-* Fix - paypal-overlay-uid_ blocks page after closing PayPal popup on Pay for Order page | Terms checkbox validation fails on Pay for Order page #1704
-* Enhancement - Add support for HPOS for tracking module #1676
-* Enhancement - Billing agreements endpoint called too frequently for Reference Transactions check #1646
-* Enhancement - Do not declare subscription support for PayPal when only ACDC vaulting #1669
-* Enhancement - Apply Capture On Status Change only when order contains PayPal payment method #1595
-* Enhancement - Do not use transient expiration longer than one month to support memcached #1448
-* Enhancement - By disconnecting or disabling the plugin the connection should clear the Onboarding links from cache #1668
-* Enhancement - Upgrade tracking integration #1562
-* Enhancement - Include url & image_url in create order call #1649
-* Enhancement - Add compat layer for Yith tracking #1656
-* Enhancement - Improve invalid currency backend notice (1926) #1588
-* Enhancement - Hide ACDC footer frame via CSS to avoid empty space #1613
-* Enhancement - Compatibility with WooCommerce Product Add-Ons plugin #1586
-* Enhancement - Remove "no shipment" message after adding tracking #1674
-* Enhancement - Improve error & success validation messages #1675
-* Enhancement - Compatibility with third-party "Product Add-Ons" plugins #1601
-* Enhancement - PayPal logo flashes when switching between tabs #1345
-* Enhancement - Include url & image_url in create order call #1649
-* Enhancement - Include item_url & image_url to tracking call #1712
-* Enhancement - Update strings for tracking metabox #1714
-* Enhancement - Validate email address API credentials field #1691
-* Enhancement - Set payment method title for order edit page only if our gateway #1661
-* Enhancement - Fix missing Pay Later messages in cart + refactoring #1683
-* Enhancement - Product page PP button keep loading popup - "wc_add_to_cart_params is not defined" error in WooCommerce #1655
-* Enhancement - Remove PayPal Subscriptions API feature flag #1690
-* Enhancement - Don't send image_url when it is empty #1678
-* Enhancement - Subscription support depending on Vaulting setting instead of subscription mode setting #1697
-* Enhancement - Wrong PayPal subscription id on vaulted subscriptions #1699
-* Enhancement - Remove payment vaulted checker functionality (2030) #1711
-* Feature preview - Apple Pay integration #1514
-* Feature preview - Google Pay integration #1654
-
-= 2.2.2 - 2023-08-29 =
-* Fix - High rate of auth voids on vaulted subscriptions for guest users #1529
-* Enhancement - HPOS compatibility issues #1594
-* Feature preview - PayPal Subscriptions API fixes and improvements #1600 #1607
-
-= 2.2.1 - 2023-08-24 =
-* Fix - One-page checkout causes mini cart not showing the PP button on certain pages #1536
-* Fix - When onboarding loading the return_url too fast may cause the onboarding to fail #1565
-* Fix - PayPal button doesn't work for variable products on product page after recent 2.2.0 release #1533
-* Fix - Send payee_preferred correctly for instant payments #1489
-* Fix - Auto-disabled ACDC vaulting after updating to 2.1.0 #1490
-* Fix - PayPal Payments serializing formData of array inputs #1501
-* Fix - Buttons not working on single product page for WooCommerce Bookings product #1478
-* Enhancement - PayPal Later message price amount doesn't update dynamically #1585
-* Enhancement - Improve WC order creation in webhook #1530
-* Enhancement - Refactor hosted fields for early card detection #1554
-* Enhancement - Pay Later button and message get hidden when product/cart/checkout value is outside of range #1511
-* Enhancement - Add link to manual credential docs #1430
-* Enhancement - Validate Merchant ID field format when saving settings #1509
-* Enhancement - Include soft descriptor for card's activity #1427
-* Enhancement - Update Pay Later amount on the cart page and checkout when total changes #1441
-* Enhancement - Log Subscription Mode configuration in system report #1507
-* Enhancement - HPOS compatibility issues #1555
-* Feature preview - PayPal Subscriptions API fixes and improvements #1443
-
-= 2.2.0 - 2023-07-17 =
-* Fix - Improve handling of APM payments when buyer did not return to Checkout #1233
-* Fix - Use order currency instead of shop currency on order-pay page #1363
-* Fix - Do not show broken card button gateway when no checkout location #1358
-* Fix - Smart buttons not greyed out/removed on single product when deselecting product variation #1469
-* Fix - Type error with advanced columns pro #1367
-* Fix - Undefined array key 0 when checking $retry_errors in process_payment method #1375
-* Fix - Advanced Card Processing gateway becomes invisible post-plugin update unless admin pages are accessed once #1432
-* Fix - Incompatibility with WooCommerce One Page Checkout (or similar use cases) in Version 2.1.0 #1473
-* Fix - Prevent Repetitive Token Migration and Database Overload After 2.1.0 Update #1461
-* Fix - Onboarding from connection page with CSRF parameter manipulates email and merchant id fields #1502
-* Fix - Do not complete non-checkout button orders via webhooks #1513
-* Enhancement - Remove feature flag requirement for express cart/checkout block integration #1483
-* Enhancement - Add notice when shop currency is unsupported #1433
-* Enhancement - Improve ACDC error message when empty fields #1360
-* Enhancement - Do not exclude free items #1362
-* Enhancement - Trigger WC checkout_error event #1384
-* Enhancement - Update wording in buttons previews #1408
-* Enhancement - Filter to conditionally block the PayPal buttons #1485
-* Enhancement - Display funding source on the admin order page #1450
-* Enhancement - Update system report plugin status for Vaulting #1471
-* Enhancement - Revert Elementor Pro Checkout hook compatibility #1482
-
-= 2.1.0 - 2023-06-13 =
-* Fix - Performance issue #1182
-* Fix - Webhooks not registered when onboarding with manual credentials #1223
-* Fix - Boolean false type sent as empty value when setting cache #1313
-* Fix - Ajax vulnerabilities #1411
-* Enhancement - Save and display vaulted payment methods in WC Payment Token API #1059
-* Enhancement - Cache webhook verification results #1379
-* Enhancement - Refresh checkout totals after validation if needed #1294
-* Enhancement - Improve Divi and Elementor Pro compatibility #1254
-* Enhancement - Add MX and JP to ACDC #1415
-* Enhancement - Add fraudnet script to SGO filter #1366
-* Feature preview - Add express cart/checkout block #1346
-* Feature preview - Integrate PayPal Subscriptions API #1217
-
-= 2.0.5 - 2023-05-31 =
-* Fix - Potential invalidation of merchant credentials #1339
-
-= 2.0.4 - 2023-04-03 =
-* Fix - Allow Pay Later in mini-cart #1221
-* Fix - Duplicated auth error when credentials become wrong #1229
-* Fix - Webhook issues when switching sandbox, and delete all webhooks when unsubscribing #1239
-* Fix - High volume of traffic from merchant-integrations endpoint #1273
-* Fix - Add content type json to all fetch ajax endpoints #1275
-* Enhancement - Remove shortcodes from description #1226
-* Enhancement - Handle price suffix with price for product button check #1234
-* Enhancement - Show funding source as payment method #1220
-* Enhancement - Change "Enabled" to "Available" in status text #1237
-* Enhancement - Programmatically capturing/voiding authorized payments #590
-
-= 2.0.3 - 2023-03-14 =
-* Fix - `DEVICE_DATA_NOT_AVAILABLE` error message when FraudNet is enabled #1177
-* Fix - Redirect to connection tab after manual credentials input #1201
-* Fix - Asking for address fields in checkout when not using them #1089
-* Fix - Validate before free trial #1170
-* Fix - Validate new user creation #1131
-* Fix - After Updating to 2.0.2, Site Health reports REST API error #1195
-* Fix - Do not send buyer-country for previews in live mode to avoid error #1186
-* Fix - PPEC compatibility layer does not take over subscriptions #1193
-* Fix - Checkout conflict with "All products for subscriptions" plugin #629
-* Fix - Pay Later on order pay page #1214
-* Fix - High volume of traffic from merchant-integrations endpoint #1241
-* Enhancement - Save checkout form before free trial redirect #1135
-* Enhancement - Add filter for controlling the ditching of items/breakdown #1146
-* Enhancement - Add patch order data filter #1147
-* Enhancement - Add filter for disabling fees on wc order admin pages #1153
-* Enhancement - Use wp_loaded for fraudnet loading to avoid warnings #1172
-* Enhancement - reCaptcha for WooCommerce support #1093
-* Enhancement - Make it possible to hide missing funding resource Trustly #1155
-* Enhancement - Add white color option #1167
-* Enhancement - Checkout validation for other fields #861
-* Enhancement - Mention PUI only for German shops and add line breaks #1169
-* Enhancement - Add filter to fallback tracking_data['carrier'] #1188
-* Enhancement - Error notices in checkout do not update / or are shown twice #1168
-* Enhancement - capture authorized payment by changing order status (or programmatically) #587
-
-= 2.0.2 - 2023-01-31 =
-* Fix - Do not call PayPal get order by ID if it does not exist #1029
-* Fix - Type check error conflict with German Market #1056
-* Fix - Backend Storage for the PayPalRequestIdRepository does not scale #983
-* Fix - Ensure WC()->payment_gateways is not null #1128
-* Enhancement - Remove plugin data after uninstalling #1075
-* Enhancement - Add FraudNet to all payments #1040
-* Enhancement - Update "Standard Payments" tab settings #1065
-* Enhancement - Update PHP 7.2 requirement in all relevant files #1084
-* Enhancement - When PUI is enabled FraudNet should be also enabled #1129
-* Enhancement - Add PayPal-Request-Id if payment source exist #1132
-
-= 2.0.1 - 2022-12-13 =
-* Fix - Error while syncing tracking data to PayPal -> Sync GZD Tracking #1020
-* Fix - Fix product price retrieval for variable product buttons #1000
-* Fix - All tabs hidden on OXXO tab visit #1048
-* Fix - Woocommerce Germanized Invoice bug #1017
-* Fix - Fix shipping address validation #1047
-* Fix - Trigger WC JS validation on button click to highlight empty fields #1004
-* Fix - Fix PHP 8.1 deprecated error #1009
-* Fix - Wrong asset path Germanized compat #1051
-* Fix - Fix DCC error messages handling #1035
-* Fix - Execute WC validation only for smart buttons in checkout #1074
-* Enhancement - Param types removed in closure to avoid third-party issues #1046
-
-= 2.0.0 - 2022-11-21 =
-* Add - Option to separate JSSDK APM payment buttons into individual WooCommerce gateways #671
-* Add - OXXO APM (Alternative Payment Method) #684
-* Add - Pay Later tab #961
-* Add - Button preview in settings #929
-* Fix - Prevent Enter key submit for our non-standard button gateways #981
-* Fix - Pay Upon Invoice - Stock correction on failed orders #964
-* Fix - Check that WC session exists before using it #846
-* Fix - Compatibility with One Page Checkout Extension #356
-* Fix - Tracking status filter sending wrong parameter #970
-* Enhancement - Compatibility with WC High-Performance Order Storage #933
-* Enhancement - PHP 8.1 warning: Constant FILTER_SANITIZE_STRING is deprecated #867
-* Enhancement - Execute server-side WC validation when clicking button #942
-* Enhancement - Update order with order note if payment failed after billing agreement canceled at PayPal #886
-* Enhancement - Missing PUI refund functionality from WC order #937
-* Enhancement - Hide Pay upon Invoice tab if not available for merchant #978
-* Enhancement - Handle synced sub without upfront payment like free trial #936
-* Enhancement - Isolate container and modularity deps #972
-  **NOTE**: if you were extending/modifying the plugin using the modularity system,
-  you will need to add the `WooCommerce\PayPalCommerce\Vendor\`  prefix for the container/modularity namespaces in your code,
-  that is `Psr\Container\ContainerInterface` becomes `WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface`,
-  and `Dhii\Modular\Module\ModuleInterface` becomes `WooCommerce\PayPalCommerce\Vendor\Dhii\Modular\Module\ModuleInterface`.
-* Enhancement - PUI gateway displayed on pay for order page when mandatory billing fields are left empty or country is unsupported #966
-* Enhancement - When Brand Name field is left empty, PUI purchase fails #916
-* Enhancement - Improve styling when using separate buttons #996
-
-= 1.9.5 - 2022-11-01 =
-* Fix - Invalid tracking number in logs when adding tracking #903
-* Fix - Tracking on Connection tab always enabled #900
-* Fix - PUI payment instructions printed in the refund email #873
-* Fix - Fix `thankyou_order_received` filter usage #899
-* Enhancement - Add SCA payment indicator for credit card renewals #847
-* Enhancement - Rename plugin settings tabs #893
-* Enhancement - Hide order button via class #921
-* Enhancement - Tracking integration compatibility with Germanized plugin #883
-* Enhancement - Onboarding buttons must be clicked multiple times after using PUI checkbox #851
-* Enhancement - Ratepay payment instructions added to non Pay upon Invoice orders #892
-* Enhancement - During PayPal express checkout PUI js file is loaded #905
-* Enhancement - PayPal Transaction Key meta field not populated for PUI payments #897
-* Enhancement - Onboard with PUI Checkbox automatically set when shop is set to Germany #876
-* Enhancement - Update all plugin strings #946
-
-= 1.9.4 - 2022-10-11 =
-* Add - Create new connection tab #801
-* Add - Functionality to choose subscription failure behavior #728
-* Fix - Virtual-only orders always move order status to completed #868
-* Fix - PayPal order created twice when context is checkout #832
-* Enhancement - Handle unsupported browsers better #843
-* Enhancement - Combine the Webhooks Status page into a new Connection tab (891) #827
-* Enhancement - Hide PayPal Card Processing tab if not available in country or for merchant #870
-* Enhancement - Resubscribe webhooks on plugin upgrades #838
-* Enhancement - PUI-relevant webhook not subscribed to #842
-* Enhancement - Remove WC logo during onboarding #881
-
-= 1.9.3 - 2022-08-31 =
-* Add - Tracking API #792
-* Fix - Improve compatibility with Siteground Optimizer plugin #797
-* Fix - Transaction ID in order not updated when manually capturing authorized payment from WC #766
-* Fix - Failed form validation on Checkout page causing page to be sticky #781
-* Fix - Do not include full path in exception #779
-* Fix - PUI conflict with Germanized plugin and taxes #808
-* Enhancement - Enable ACDC by default only in locations where WooCommerce Payments is not available #799
-* Enhancement - Add links to docs & support in plugin #782
-* Enhancement - Put gateway sub-options into tabs #772
-* Enhancement - Show tabs only after onboarding #789
-* Enhancement - Add header on settings page #790
-* Enhancement - PUI add option for a phone number field next to the Birth Date field #742
-* Enhancement - PUI gateway availability on pay for order page with unsupported currency #744
-
-= 1.9.2 - 2022-08-09 =
-* Fix - Do not allow birth date older than 100 years for PUI. #743
-* Fix - Store the customer id for vaulted payment method in usermeta to not lose vaulted methods after the invoice prefix change. #698
-* Fix - Capture Virtual-Only Orders setting did not auto-capture subscription renewal payments. #626
-* Fix - Voiding authorization at PayPal did not update the status/order notes. #712
-* Fix - PayPal scripts were loading on pages without smart buttons or Pay Later messaging. #750
-* Fix - Do not show links for unavailable gateways settings pages. #753
-* Fix - The smart buttons were not loaded on single product page if a subscription product exists in the cart. #703
-* Fix - DCC was causing other gateways to disappear after checkout validation error. #757
-* Fix - Buttons not loading on single product page with default settings when product is in cart. #777
-* Enhancement - Improve Checkout Field Validation Message. #739
-* Enhancement - Handle PAYER_ACTION_REQUIRED error. #759
-
-= 1.9.1 - 2022-07-25 =
-* Fix - ITEM_TOTAL_MISMATCH error when checking out with multiple products #721
-* Fix - Unable to purchase a product with Credit card button in pay for order page #718
-* Fix - Pay Later messaging only displayed when smart button is active on the same page #283
-* Fix - Pay Later messaging displayed for out of stock variable products or with no variation selected #667
-* Fix - Placeholders and card type detection not working for PayPal Card Processing (260) #685
-* Fix - PUI gateway is displayed with unsupported store currency #711
-* Fix - Wrong PUI locale sent causing error PAYMENT_SOURCE_CANNOT_BE_USED #741
-* Enhancement - Missing PayPal fee in WC order details for PUI purchase #714
-* Enhancement - Skip loading of PUI js file on all pages where PUI gateway is not displayed #723
-* Enhancement - PUI feature capitalization not consistent #724
-
-= 1.9.0 - 2022-07-04 =
-* Add - New Feature - Pay Upon Invoice (Germany only) #608
-* Fix - Order not approved: payment via vaulted PayPal account fails #677
-* Fix - Cant' refund : "ERROR Refund failed: No country given for address." #639
-* Fix - Something went wrong error in Virtual products when using vaulted payment #673
-* Fix - PayPal smart buttons are not displayed for product variations when parent product is set to out of stock #669
-* Fix - Pay Later messaging displayed for out of stock variable products or with no variation selected #667
-* Fix - "Capture Virtual-Only Orders" intent sets virtual+downloadable product orders to "Processing" instead of "Completed" #665
-* Fix - Free trial period causing incorrerct disable-funding parameters with DCC disabled #661
-* Fix - Smart button not visible on single product page when product price is below 1 and decimal is "," #654
-* Fix - Checkout using an email address containing a + symbol results in a "[INVALID_REQUEST]" error #523
-* Fix - Order details are sometimes empty in PayPal dashboard #689
-* Fix - Incorrect TAX details on PayPal order overview #541
-* Fix - Fatal error: Uncaught Error: Call to a member function get_name() on bool #622
-* Fix - DCC causes checkout continuation state after checkout validation error #695
-* Enhancement - Improve checkout validation & order creation #513
-
-= 1.8.1 - 2022-05-31 =
-* Fix - Manual orders return an error for guest users when paying with PayPal Card Processing #530
-* Fix - "No PayPal order found in the current WooCommerce session" error for guests on Pay for Order page #605
-* Fix - Error on order discount by third-party plugins #548
-* Fix - Empty payer data may cause CITY_REQUIRED error for certain checkout countries #632
-* Fix - Mini Cart smart buttons visible after adding subscription product to cart from "shop" page while Vaulting is disabled #624
-* Fix - Smart buttons not loading when free product is in cart but shipping costs are available #606
-* Fix - Smart button & Pay Later messaging disappear on the cart page after changing shipping method #288
-* Fix - Disabling PayPal Checkout on the checkout page also removes the button from the Cart and Product Pages #577
-* Fix - Partial refunds via PayPal are created twice/double in WooCommerce order #522
-* Fix - Emoji in product description causing INVALID_STRING_LENGTH error #491
-* Enhancement - Vaulting & Pay Later UI/UX #174
-* Enhancement - Redirect after updating settings for DCC sends you to PPCP settings screen #392
-* Enhancement - Add Fraud Processor Response as an order note #616
-* Enhancement - Add the Paypal Fee to the Meta Custom Field for export purposes #591
-
-= 1.8.0 - 2022-05-03 =
-* Add - Allow free trial subscriptions #580
-* Fix - The Card Processing does not appear as an available payment method when manually creating an order #562
-* Fix - Express buttons & Pay Later visible on variable Subscription products /w disabled vaulting #281
-* Fix - Pay for order (guest) failing when no email address available #535
-* Fix - Emoji in product description causing INVALID_STRING_LENGTH error #491
-* Enhancement - Change cart total amount that is sent to PayPal gateway #486
-* Enhancement - Include dark Visa and Mastercard gateway icon list for PayPal Card Processing #566
-* Enhancement - Onboarding errors improvements #558
-* Enhancement - "Place order" button visible during gateway load time when DCC gateway is selected as the default #560
-
-= 1.7.1 - 2022-04-06 =
-* Fix - Hide smart buttons for free products and zero-sum carts #499
-* Fix - Unprocessable Entity when paying with AMEX card #516
-* Fix - Multisite path doubled in ajax URLs #528
-* Fix - "Place order" button looking unstyled in the Twenty Twenty-Two theme #478
-* Fix - PayPal options available on minicart when adding subscription to the cart from shop page without vaulting enabled #518
-* Fix - Buttons not visible on products page #551
-* Fix - Buttons not visible in mini-cart #553
-* Fix - PayPal button missing on pay for order page #555
-* Enhancement - PayPal buttons loading time #533
-* Enhancement - Improve payment token checking for subscriptions #525
-* Enhancement - Add Spain and Italy to messaging #497
-
-= 1.7.0 - 2022-02-28 =
-* Fix - DCC orders randomly failing #503
-* Fix - Multi-currency broke #481
-* Fix - Address information from PayPal shortcut flow not loaded #451
-* Fix - WooCommerce as mu-plugin is not detected as active #461
-* Fix - Check if PayPal Payments is an available gateway before displaying it on Product/Cart pages #447
-* Enhancement - Improve onboarding flow, allow no card processing #443 #508 #510
-* Enhancement - Add Germany to supported ACDC countries #459
-* Enhancement - Add filters to allow ACDC for countries #437
-* Enhancement - Update 3D Secure #464
-* Enhancement - Extend event, error logging & order notes #456
-* Enhancement - Display API response errors in checkout page with user-friendly error message #457
-* Enhancement - Pass address details to credit card fields #479
-* Enhancement - Improve onboarding notice #465
-* Enhancement - Add transaction ID to WC order and order note when refund is received #473
-* Enhancement - Asset caching may cause bugs on upgrades #501
-* Enhancement - Allow partial capture #483
-* Enhancement - PayPal Payments doesn't set transaction fee metadata #467
-* Enhancement - Show PayPal fee information in order #489
-
-= 1.6.5 - 2022-01-31 =
-* Fix - Allow guest users to purchase subscription products from checkout page #422
-* Fix - Transaction ID missing for renewal order #424
-* Fix - Save your credit card checkbox should be removed in pay for order for subscriptions #420
-* Fix - Null currency error when the Aelia currency switcher plugin is active #426
-* Fix - Hide Reference Transactions check from logs #428
-* Fix - Doubled plugin module URL path causing failure #438
-* Fix - is_ajax deprecated #441
-* Fix - Place order button from PayPal Card Processing does not get translated #290
-* Fix - AMEX missing from supported cards for DCC Australia #432
-* Fix - "Save your Credit Card" text not clickable to change checkbox state #430
-* Fix - Improve DCC error notice when not available #435
-* Enhancement - Add View Logs link #416
-
-= 1.6.4 - 2021-12-27 =
-* Fix - Non admin user cannot save changes to the plugin settings #278
-* Fix - Empty space in invoice prefix causes smart buttons to not load #390
-* Fix - woocommerce_payment_complete action not triggered for payments completed via webhook #399
-* Fix - Paying with Venmo - Change funding source on checkout page and receipt to Venmo  #394
-* Fix - Internal server error on checkout when selected saved card but then switched to paypal #403
-* Enhancement - Allow formatted text for the Description field #407
-* Enhancement - Remove filter to prevent On-Hold emails #411
-
-= 1.6.3 - 2021-12-14 =
-* Fix - Payments fail when using custom order numbers #354
-* Fix - Do not display saved payments on PayPal buttons if vault option is disabled #358
-* Fix - Double "Place Order" button #362
-* Fix - Coupon causes TAX_TOTAL_MISMATCH #372
-* Fix - Funding sources Mercado Pago and BLIK can't be disabled #383
-* Fix - Customer details not available in order and name gets replaced by xxx@dcc2.paypal.com #378
-* Fix - 3D Secure failing for certain credit card types with PayPal Card Processing #379
-* Fix - Error messages are not cleared even when checkout is re-attempted (DCC) #366
-* Add - New additions for system report status #377
-
-= 1.6.2 - 2021-11-22 =
-* Fix - Order of WooCommerce checkout actions causing incompatibility with AvaTax address validation #335
-* Fix - Can't checkout to certain countries with optional postcode #330
-* Fix - Prevent subscription from being purchased when saving payment fails #308
-* Fix - Guest users must checkout twice for subscriptions, no smart buttons loaded #342
-* Fix - Failed PayPal API request causing strange error #347
-* Fix - PayPal payments page empty after switching packages #350
-* Fix - Could Not Validate Nonce Error #239
-* Fix - Refund via PayPal dashboard does not set the WooCommerce order to "Refunded" #241
-* Fix - Uncaught TypeError: round() #344
-* Fix - Broken multi-level (nested) associative array values after getting submitted from checkout page #307
-* Fix - Transaction id missing in some cases #328
-* Fix - Payment not possible in pay for order form because of terms checkbox missing #294
-* Fix - "Save your Credit Card" shouldn't be optional when paying for a subscription #368
-* Fix - When paying for a subscription and vaulting fails, cart is cleared #367
-* Fix - Fatal error when activating PayPal Checkout plugin #363
-
-= 1.6.1 - 2021-10-12 =
-* Fix - Handle authorization capture failures #312
-* Fix - Handle denied payment authorization #302
-* Fix - Handle failed authorizations when capturing order #303
-* Fix - Transactions cannot be voided #293
-* Fix - Fatal error: get_3ds_contingency() #310
-
-= 1.6.0 - 2021-09-29 =
-* Add - Webhook status. #246 #273
-* Add - Show CC gateway in admin payments list. #236
-* Add - Add 3d secure contingency settings. #230
-* Add - Improve logging. #252 #275
-* Add - Do not send payee email. #231
-* Add - Allow customers to see and delete their saved payments in My Account. #274
-* Fix - PayPal Payments generates multiple orders. #244
-* Fix - Saved credit card does not auto fill. #242
-* Fix - Incorrect webhooks registration. #254
-* Fix - Disable funding credit cards affecting hosted fields, unset for GB. #249
-* Fix - REFUND_CAPTURE_CURRENCY_MISMATCH on multicurrency sites. #225
-* Fix - Can't checkout to certain countries with optional postcode. #224
-
-= 1.5.1 - 2021-08-19 =
-* Fix - Set 3DS contingencies to "SCA_WHEN_REQUIRED". #178
-* Fix - Plugin conflict blocking line item details. #221
-* Fix - WooCommerce orders left in "Pending Payment" after a decline. #222
-* Fix - Do not send decimals when currency does not support them. #202
-* Fix - Gateway can be activated without a connected PayPal account. #205
-
-= 1.5.0 - 2021-08-09 =
-* Add - Filter to modify plugin modules list. #203
-* Add - Filters to move PayPal buttons and Pay Later messages. #203
-* Fix - Remove redirection when enabling payment gateway with setup already done. #206
-* Add - PayPal Express Checkout compatibility layer. #207
-* Fix - Use correct API to obtain credit card icons. #210
-* Fix - Hide mini cart height field when mini cart is disabled. #213
-* Fix - Address possible error on frontend pages due to an empty gateway description. #214
-
-= 1.4.0 - 2021-07-27 =
-* Add - Venmo update #169
-* Add - Pay Later Button –Global Expansion #182
-* Add - Add Canada to advanced credit and debit card #180
-* Add - Add button height setting for mini cart #181
-* Add - Add BN Code to Pay Later Messaging #183
-* Add - Add 30 seconds timeout by default to all API requests #184
-* Fix - ACDC checkout error: "Card Details not valid"; but payment completes #193
-* Fix - Incorrect API credentials cause fatal error #187
-* Fix - PayPal payment fails if a new user account is created during the checkout process #177
-* Fix - Disabled PayPal button appears when another button is loaded on the same page #192
-* Fix - [UNPROCESSABLE_ENTITY] error during checkout #172
-* Fix - Do not send customer email when order status is on hold #173
-* Fix - Remove merchant-id query parameter in JSSDK #179
-* Fix - Error on Plugin activation with Zettle POS Integration for WooCommerce #195
-
-= 1.3.2 - 2021-06-08 =
-* Fix - Improve Subscription plugin support. #161
-* Fix - Disable vault setting if vaulting feature is not available. #150
-* Fix - Cast item get_quantity into int. #168
-* Fix - Fix Credit Card form fields placeholder and label. #146
-* Fix - Filter PayPal-supported language codes. #154
-* Fix - Wrong order status for orders with contain only products which are both virtual and downloadable. #145
-* Fix - Use order_number instead of internal id when creating invoice Id. #163
-* Fix - Fix pay later messaging options. #141
-* Fix - UI/UX for vaulting settings. #166
-
-= 1.3.1 - 2021-04-30 =
-* Fix - Fix Credit Card fields for non logged-in users. #152
-
-= 1.3.0 - 2021-04-28 =
-* Add - Client-side vaulting and allow WooCommerce Subscriptions product renewals through payment tokens. #134
-* Add - Send transaction ids to woocommerce. #125
-* Fix - Validate checkout form before sending request to PayPal #137
-* Fix - Duplicate Invoice Id error. #143
-* Fix - Unblock UI if Credit Card payment failed. #122
-* Fix - Detected container element removed from DOM. #123
-* Fix - Remove disabling credit for UK. #127
-* Fix - Show WC message on account creating error. #136
-
-= 1.2.1 - 2021-03-08 =
-* Fix - Address compatibility issue with Jetpack.
-
-= 1.2.0 - 2021-03-08 =
-* Add - Rework onboarding code and add REST controller for integration with the OBW. #121
-* Fix - Remove spinner on click, on cancel and on error. #124
-
-= 1.1.0 - 2021-02-01 =
-* Add - Buy Now Pay Later for UK. #104
-* Add - DE now has 12 month installments. #106
-* Fix - Check phone for empty string. #102
-
-= 1.0.4 - 2021-01-18 =
-* Fix - Check if WooCommerce is active before initialize. #99
-* Fix - Payment buttons only visible on order-pay site when Mini Cart is enabled; payment fails. #96
-* Fix - High volume of failed calls to /v1/notifications/webhooks #93
-* Fix - GB country has ACDC blocked. #91
-
-= 1.0.3 - 2020-11-30 =
-* Fix - Order with Payment received when Hosted Fields transaction is declined. #88
-
-= 1.0.2 - 2020-11-09 =
-* Fix - Purchases over 1.000 USD fail. #84
-
-= 1.0.1 - 2020-11-05 =
-* Fix - PayPal Smart buttons don't load when using a production/live account and `WP_Debug` is turned on/true. #66
-* Fix - [Card Processing] SCA/Visa Verification form loads underneath the Checkout blockUI element. #63
-* Fix - Attempting to checkout without country selected results in unexpected error message. #67
-* Fix - Remove ability to change shipping address on PayPal from checkout page. #72
-* Fix - Amount value should be a string when send to the api. #76
-* Fix - "The value of a field does not conform to the expected format" error when using certain e-mail addresses. #56
-* Fix - HTML tags in Product description. #79
-
-= 1.0.0 - 2020-10-15 =
+2025-05-12 - version 4.1.3
+* Fix           - Resolved issue with subscription renewal from 'My account' for WooCommerce Subscriptions.
+* Fix           - Resolved issue that in certain circumstances could cause the checkout to reload infinitely.
+* Tweak         - Improved frontend logging.
+
+2025-04-28 - version 4.1.2
+* Fix           - Resolved the Express Checkout option being shown in the cart for free orders.
+* Fix           - Resolved session related issue for pay for order.
+* Fix           - Resolved the cart hash not being updated for some cart changes.
+
+2025-04-03 - version 4.1.1
+* Fix           - Removed empty array metadata from Klarna unavailable features request to comply with Klarna's required object format.
+
+2025-04-01 - version 4.1.0
+* Feature       - Added the 'kp_get_customer_type' filter for modifying the customer type.
+* Feature       - Added the Klarna interoperability token.
+* Fix           - Added a control to check whether the checkout should be reloaded. This should address the issue where if placing orders without an account is disabled caused a checkout error.
+* Tweak         - Updated the platform plugin data.
+
+2025-03-14 - version 4.0.3
+* Fix           - Limit the max size of a log message from the frontend to 1000 characters to prevent large logs from being created.
+
+2025-02-20 - version 4.0.2
+* Fix           - Bumped release version.
+
+2025-02-20 - version 4.0.1
+* Fix           - Resolved issue where users with some unavailable Klarna feature set for their credentials, sometimes had KP made unavailable when saving their settings. Settings needs to be saved again for an update to take place, where this is an issue.
+
+2025-02-18 - version 4.0.0
+* Feature       - Added credential-based visibility for the different Klarna features.
+
+2025-02-17 - version 3.9.2
+* Feature       - Added support for subscriptions in the block-based checkout.
+* Tweak         - Added a privacy notice under the Credentials section.
+* Tweak         - Added environmental information to the order.
+* Fix           - Fixed potential for fatal error on check if order is created via block-based checkout or not.
+
+2025-01-20 - version 3.9.1
+* Fix           - Fixed active/inactive badge not always showing the expected status.
+
+2025-01-13 - version 3.9.0
+* Feature       - Added active/inactive badge to features in settings.
+* Feature       - [KOSM] Added enable/disable setting for KOSM.
+* Tweak         - Orders rejected by Klarna after the order has been placed in WooCommerce will now receive status "failed".
+* Tweak         - Added "Select all" country option to credentials section in settings.
+* Tweak         - Removed filter for payment method title.
+* Fix           - Resolved the Klarna Payments block not showing for the twentytwentyfour theme's blocks checkout.
+* Fix           - Resolved "Incompatible with blocks" warning for Klarna Payments in the block checkout editor.
+* Fix           - Resolved "Textdomain was called incorrectly" notice.
+* Fix           - [KOSM] Resolved "Attempt to read property on null" warning.
+* Fix           - [KOSM] Resolved data-environment tag not being set correctly.
+* Fix           - [SIWK] Fixed faulty formatting for scope and removed invalid scope.
+* Fix           - Bumped release version.
+
+2024-11-12 - version 3.8.3
+* Fix           - Fixed an issue where the customer could place an order on the pay for order page without consenting to the terms and conditions.
+* Tweak         - The checkout will be blocked while the checkout is being processed.
+* Tweak         - If the locale is modified, the existing session will be dropped, and a new one will be created. This should ensure that Klarna has the correct locale, and improve compatibility with i18n plugins.
+* Feature       - [KOSM] Added the 'kosm_show_everywhere' filter hook to allow the placement to be shown on all pages.
+* Tweak         - [KOSM] Updated the product description.
+* Tweak         - [KEC] The KEC button will remain hidden on a variable product page until a variant is selected.
+* Tweak         - [KEC] Updated the product description.
+* Tweak         - [SIWK] Updated the product description.
+* Fix           - [Settings] Fixed an issue where the preview would still show the old preview after updating the settings until the user refreshes the page.
+* Fix           - Bump release version.
+
+2024-11-12 - version 3.8.2
+* Fix           - Fixed an issue where the customer could place an order on the pay for order page without consenting to the terms and conditions.
+* Tweak         - The checkout will be blocked while the checkout is being processed.
+* Tweak         - If the locale is modified, the existing session will be dropped, and a new one will be created. This should ensure that Klarna has the correct locale, and improve compatibility with i18n plugins.
+* Feature       - [KOSM] Added the 'kosm_show_everywhere' filter hook to allow the placement to be shown on all pages.
+* Tweak         - [KOSM] Updated the product description.
+* Tweak         - [KEC] The KEC button will remain hidden on a variable product page until a variant is selected.
+* Tweak         - [KEC] Updated the product description.
+* Tweak         - [SIWK] Updated the product description.
+* Fix           - [Settings] Fixed an issue where the preview would still show the old preview after updating the settings until the user refreshes the page.
+
+2024-10-30 - version 3.8.1
+* Fix           - [SIWK] Fixed and issue with the "Sign in with Klarna" showing even when the feature was disabled.
+
+2024-10-25 - version 3.8.0
+* Feature       - Added support for "Sign in with Klarna" for an improved way to drive shoppers straight to the checkout, with all their preferences already set.
+
+2024-10-23 - version 3.7.4
+* Fix           - Fixed an undefined index warning related to new settings.
+* Fix           - [KOSM] Fixed the On-site messaging preview not changing to reflect the selected theme.
+* Fix           - [KOSM] Fixed an uncaught error when rendering the On-site messaging preview.
+* Tweak         - [KEC] The Klarna Express Checkout ("KEC") button will now be hidden on a variable product page until a variant is selected.
+* Tweak         - [Settings] Added links to plugin and additional resources.
+
+2024-09-13 - version 3.7.3
+* Fix           - Fix an issue with getting the correct credentials in some cases when not using the combined setting for EU countries.
+
+2024-09-12 - version 3.7.2
+* Fix           - Fixed a undefined index warning related to new settings.
+
+2024-09-11 - version 3.7.1
+* Fix           - Fixed a issue with getting the correct client id when not combining all EU countries into a single setting.
+* Tweak         - Bumped version for krokedil/woocommerce dependency.
+
+2024-09-11 - version 3.7.0
+* Changed       - Changed the settings page to follow a new design that's more streamlined and matching with Klarnas other products.
+* Changed       - Changed the payment method name to be Klarna instead of Klarna Payments.
+* Feature       - Added a setting to combine all EU country credentials into a single setting field, for cases where you use the same merchant id and secret for multiple countries that you sell to with Klarna Payments.
+* Feature       - Added settings for each region to have their own Client ID that can be used by On-Site Messaging, Express Checkout and other products from Klarna instead of these having to add the setting separately. This will also allow for more control of the regions these features are available in.
+* Feature       - Added a setting to set what countries are available for the payment method. This will be skipped if it is empty to prevent issues until stores can update the setting properly.
+* Feature       - Added a Support tab on the settings page for the gateway. This will allow stores to open a support ticket directly with Krokedil from the plugin, and has the ability to attach the system report. And has links to other resources such as plugin documentation and information.
+* Feature       - Added a Addons tab on the settings page for the gateway. This will show other plugins developed by Krokedil that work well together with the plugin that can provide additional features to the WooCommerce store.
+* Fix           - Fixed potential issues caused by other plugins having similar composer dependencies but with different versions by scoping the plugins dependencies.
+* Fix           - Fixed some issues in the credentials check that runs when settings are saved.
+
+2024-09-09 - version 3.6.2
+* Enhancement   - Performance improvements related to session management.
+
+2024-08-28 - version 3.6.1
+* Fix           - Fixed a critical error when retrieving PW gift card from a Woo order.
+* Fix           - Fixed a division by zero when calculating the tax rate.
+* Fix           - Fixed an undefined index warning by ensuring that PW gift card exists before attempting retrieval.
+* Fix           - Resolved an issue where Chrome ignored the autocomplete attribute for Australian credentials.
+* Fix           - Fixed an issue where the product image URLs where sent to Klarna even when the setting was disabled.
+* Tweak         - Updated the default Klarna logo.
+
+2024-08-19 - version 3.6.0
+* Feature       - Added compatibility with "Linear Checkout for WooCommerce" plugin.
+* Feature       - Added the 'kp_blocks_order_button_label' filter to change the order button label in the Klarna Payments block.
+* Fix           - Fixed divide by zero error when calculating the tax rate.
+* Tweak         - Addressed various Woo Quality Insights recommendations.
+* Tweak         - You can now overwrite the recurring payment token from the admin Subscription page.
+* Feature       - [KOSM] Added support for Slovakia.
+* Feature       - [KOSM] Added support for Hungary.
+* Feature       - [KOSM] Added 'kosm_hide_placement' filter hook for conditionally hiding the placement.
+
+2024-05-13 - version 3.5.4
+* Fix           - Fixed a critical error due to undefined method call.
+
+2024-05-13 - version 3.5.3
+* Fix           - [KOSM] Restored the theme setting "custom" (previously known as "none").
+* Fix           - [KOSM] Resolved deprecation warning in PHP 8.2.
+* Fix           - [KOSM] The disable KOSM admin banner will now only show if the KOSM plugin is enabled (previously it would always show as long as the KOSM plugin is installed).
+* Fix           - [KOSM] The shortcode should now work as intended on non-shop pages.
+* Tweak         - Enhanced compatibility with third-party gift card and coupon plugins.
+* Tweak         - The "Klarna order id" label will now only be added to the email template if the Klarna order ID is set.
+
+2024-04-23 - version 3.5.2
+* Fix           - Update package version.
+
+2024-04-22 - version 3.5.1
+* Fix           - Fixed a critical error that happened under certain conditions if the KOSM plugin is active.
+
+2024-04-22 - version 3.5.0
+* Feature       - On-site messaging is now part of the Klarna Payments plugin. With this change we've moved to the new Web SDK and resolved deprecation warnings.
+* Tweak         - Redacted sensitive information from the log.
+* Fix           - Fixed an issue where multiple KEC buttons would appear on a variable product page every time the user picked a different variant option.
+* Fix           - Moved to client_key which should resolve the client_id deprecation warning.
+
+2024-04-02 - version 3.4.2
+* Fix           - Retrieve the currency from the order where applicable. This should enhance compatibility with custom currency switchers.
+* Fix           - Prevent order from being processed more than once through callbacks.
+* Fix           - Resolve an issue where if the customer was redirected back to the store from the hosted payment page, an HTTP 409 error could occur.
+* Tweak         - Use shipping country if the billing country field is unset. Defaults to store location if none is available.
+
+2024-03-12 - version 3.4.1
+* Fix           - Fixed an issue where the name of the previous payment gateway was set on the order after changing to, and paying with Klarna Payments.
+* Fix           - Setting multiple tax rates with different priorities in WooCommerce tax settings should now work as expected.
+* Fix           - Fixed an issue introduced in WooCommerce version 8.7.0 where a critical error would occur if the cart contained any coupon.
+
+2024-01-31 - version 3.4.0
+* Feature       - Add support to pass locale to Klarna Express Checkout.
+* Fix           - Klarna Express Checkout will no longer compare the shipping address to the KEC provided address when delivery address is forced to be the billing address.
+* Fix           - Fixed an issue with WooCommerce Subscriptions that would cause a recursion error when canceling a subscription with a Klarna Payments payment method.
+
+2024-01-16 - version 3.3.1
+* Fix           - Remove the required flag from the KEC client identifier setting.
+
+2024-01-15 - version 3.3.0
+* Feature       - Added support for Klarna Express Checkout.
+* Feature       - Added support for Post Purchase Upsell.
+* Fix           - Fixed an issue with a undefined index when reading the enabled setting before it has been saved.
+* Tweak         - Changed author and author uri for the plugin.
+
+2023-12-06 - version 3.2.4
+* Fix           – Added a check to ensure that a Klarna order is always, at most, processed once. This should prevent accidental order re-processing.
+* Fix           - Fixed PHP 8 deprecation warnings.
+* Tweak         - The API password fields in the plugin settings is now treated as a password field.
+* Tweak         - Improved performance when retrieving the order. This is especially noticeable in stores with many orders (thanks @fitimvata!).
+* Tweak         - Added an extra integrity check when verifying AJAX requests.
+
+2023-11-07 - version 3.2.3
+* Fix           - If Klarna Payment is the preferred payment gateway, the first payment category should be selected by default rather than the last one (current behavior).
+
+2023-10-09 - version 3.2.2
+* Fix           - Fixed a critical error due to the class "KP_Api" being undefined.
+* Fix           - The plugin will no longer cause a critical error when its dependency, WooCommerce, is disabled.
+* Fix           - Fixed an issue related to subscriptions where the incorrect "intent" would be set.
+* Fix           - Pay for order should now work as expected.
+
+2023-08-31 - version 3.2.1
+* Fix           - Fix fatal error due to subscriptions class not available.
+
+2023-08-31 - version 3.2.0
+* Feature       - Added support for WC subscriptions.
+* Enhancement   - You can now use the 'klarna_base_region' filter to change the regional endpoint (EU, US or OC).
+* Tweak         - The KP regions in the settings should now appear in alphabetic order.
+* Fix           - Revert changes related to the setting "What is Klarna". Enabling the setting should now hide the link (like it used to) instead of making it appear.
+
+2023-07-26 - version 3.1.3
+* Fix           - Fixed an issue where the customer type defaulted to B2C even when B2B was chosen in the settings.
+
+2023-07-25 - version 3.1.2
+* Fix           - The Klarna logo will now correctly be fetched from the session as originally intended, rather than defaulting to the use of the standard logo.
+- Tweak         - We have removed the settings tab from the "Klarna Add-ons" page because its functionalities have been transferred to the plugin.
+* Tweak         - We will now validate the API credentials based on the active mode, whether it's test or production. This enhancement should prevent the plugin from inaccurately attempting to verify production credentials when the test mode is in operation.
+
+2023-06-28 - version 3.1.1
+* Fix           - Fixed an issue with how we made our meta queries when trying to find orders based on a the Klarna session ID.
+* Enhancement   - Added a validation to ensure that the order returned by our meta query actually is the correct order by verifying that the Klarna session ID stored matches the one we searched for.
+
+2023-06-20 - version 3.1.0
+* Feature       - The plugin now supports WooCommerce's "High-Performance Order Storage" ("HPOS") feature.
+* Feature       - Added support for Hungary.
+* Enhancement   - We will now use the WooCommerce JavaScript method $.scroll_to_notices() to scroll to notices when errors happen during checkout. This allows for custom overrides of the method. Thank you [@oxyc](https://github.com/oxyc)!
+* Fix           - Fixed the compatibility with YITH Giftcards.
+* Fix           - Fixed the compatibility with WooCommerce Advanced Shipping Packages
+
+
+2023-05-16 - version 3.0.7
+* Fix           - Fixed a critical error related to calculating the cart total sum. Previously, a fatal error would occur on certain PHP versions if a non-numeric item was encountered during the calculation (thanks @tobyaherbert!)
+* Fix           - Fixed an issue where essential meta data required for proper order management was missing during the pay for order payment process.
+* Fix           - Fixed an issue where the table rate shipping method used a different identifier during checkout compared to order management.
+
+2023-04-11 - version 3.0.6
+* Fix           - Fixed an issue where the client token would disappear due to a conflict with a third-party plugin, causing the Klarna payment options to not appear.
+* Fix           - Pay for order should now work as expected.
+* Fix           - When the order is being placed, the billing country should now be retrieved from the order directly. This should fix an issue with "Fluid Checkout PRO".
+* Tweak         - API errors are now only displayed on the front-end if test mode is enabled. They will still be logged provided that logging is enabled.
+
+2023-03-02 - version 3.0.5
+* Fix           - Fixed an issue where using Smart Coupons would cause a BAD_VALUE if the coupon amount was greater than the total sum of the cart content.
+* Fix           - Removed an extraneous comma which would result in a fatal error when using PHP version older than 7.3. Note: the minimum PHP version is 7.4.
+
+2023-02-27 - version 3.0.4
+* Fix           - Fixed an error message that could happen when updating your settings.
+* Fix           - Fixed an issue where we would sometimes attempt to create sessions with Klarna for countries that you do not have settings for.
+* Fix           - Fixed an issue in the logger where WordPress returns a boolean for the current WP_Hook instead of an array.
+
+2023-02-24 - version 3.0.3
+* Fix           - Fixed an issue with shipping not being present when loading the checkout page if the cart needs shipping.
+
+2023-02-22 - version 3.0.2
+* Fix           - Fixed an issue with cart fees not being processed properly, causing a potential error.
+* Fix           - Fixed a notice caused by a new setting not being set.
+
+2023-02-21 - version 3.0.1
+* Fix           - Fixed an issue with the live api url for Klarna Payments.
+
+2023-02-20 - version 3.0.0
+* Feature       - Added support for WooCommerce Checkout blocks using Klarna Payments.
+* Feature       - Added support for Romania.
+* Feature       - Added a lot more filters to everything in the requests to Klarna, to make it easier to customize the data as needed.
+* Enhancement   - Improved the logs for each request, with the ability to add a lot more information to each log. This will help with debugging issues faster.
+* Enhancement   - Reduced the amount of requests needed to place an order with Klarna.
+* Note          - This version contains a lot of major changes to the plugin, so please test thoroughly before updating to this version to ensure that it works as expected on your store.
+
+2022-10-27 - version 2.12.1
+* Fix           - Fixed a critical error when trying to clear the session.
+
+2022-10-26 - version 2.12.0
+* Feature       - Added support for "PW WooCommerce Gift Cards".
+* Fix           – Fixed an issue where “null” is returned if the tax rate could not be retrieved.
+* Tweak         - If Klarna Payments is enabled, it should now be available through the 'woocommerce_available_payment_gateways' filter. This is changed from being only available on the checkout page or when performing AJAX calls.
+* Enhancement   – You can now use the ‘kp_locale’ filter to change the Klarna locale.
+
+2022-09-27 - version 2.11.5
+* Fix           - Fix the token fragment not being updated under certain conditions (thanks !@clifgriffin).
+* Tweak         - It should no longer be any issue when KP and KCO are enabled simultaneously on the checkout.
+
+2022-07-25 - version 2.11.4
+* Fix           - Fix bug that prevent scripts from properly loading, making the checkout appear to freeze.
+
+2022-07-25 - version 2.11.3
+* Fix           - Fix undefined index.
+
+2022-07-18 - version 2.11.2
+* Fix           - Fix purchase country not being updated when the billing country is changed on the checkout page.
+
+2022-07-13 - version 2.11.1
+* Fix - Fixed an issue that would cause a critical error on versions of PHP older than 7.3. The WooCommerce team [strongly recommends](https://woocommerce.com/document/update-php-wordpress/) upgrading to PHP 7.4 for better performance and security.
+
+2022-07-12 - version 2.11.0
+* Enhancement   - Enhanced the checkout experience.
+* Tweak         - Improved compatibility with third-party theme (thanks @swarnat!)
+
+2021-05-30 - version 2.10.0
+* Feature       - Add support for Greece locale (el_GR).
+* Fix           - Fix incorrect shipping tax sometimes happening on non-integer VATs (thank you Avaroth!).
+* Fix           - Fix "Internal server error" sometimes happening when the store's country and customer's country do not match region-wise.
+* Fix           - Fix undefined index happening due to unsupported countries.
+* Fix           - Fix issue where you could not switch between KP and KCO when both plugins were enabled in the checkout at the same time.
+* Enhancement   - Klarna Payments is now available on the admin page which should improve compatibility with some third-party plugins.
+
+2021-04-27 - version 2.9.1
+* Fix           - Make sure that the checkout is fully unlocked after the Klarna popup window is closed by a customer.
+* Fix           - Check if a country is supported before getting the currency. Fixes a undefined index error message.
+
+2021-04-13 - version 2.9.0
+* Feature       - Added support for Greece and Czech Republic.
+* Enhancement   - The debug log messages that are saved on errors to the database are no longer autoloaded by us, and will only be loaded when asked for directly.
+* Fix           - Fixed an issue with the Mexico support.
+* Fix           - Fixed an issue that could occur where some plugins would strip the hashtag from the hex color in the settings, causing an error.
+
+2021-01-19 - version 2.8.1
+* Fix           - Fixed a potential fatal error when the create session request does not return a OK response.
+
+2021-01-19 - version 2.8.0
+* Feature       - Add support for Mexico.
+* Fix           - Fixerd an issue causing the wrong payment method name to be set in some cases when using pay for order.
+* Fix           - Fixed a error notice if the WooCommerce customer object is not set.
+
+2021-12-07 - version 2.7.1
+* Enhancement   - Countries that you have entered credentials for now show up on the status page.
+* Enhancement   - We will now warn you if you have put Klarna into test mode without having any test credentials filled in.
+* Enhancement   - Added an option to permanently remove the go-live banner on the admin page.
+* Fix           - Fixed an issue that could let customers press the place order button multiple times that could cause double orders.
+
+2021-11-17 - version 2.7.0
+* Feature       - Add support for Ireland.
+* Feature       - Add support for Portugal.
+* Enhancement   - Add support for YITH Giftcards.
+* Enhancement   - Add the request URL to the log for the plugin log. Thank you Maksim Kuzmin (github KuzMaxOriginal)
+* Fix           - Fixed a notice on a permalinks check. Thank you Maksim Kuzmin (github KuzMaxOriginal)
+
+2021-10-26 - version 2.6.1
+* Fix           - Prevent any load events from happening during the checkout completion stage.
+* Fix           - Fixed some undefined index errors.
+* Tweak         - Change the Klarna documentation URL in the email setting.
+
+2021-09-01 - version 2.6.0
+* Feature       - Added support for the Polish market.
+* Feature       - We will now save the last 15 requests to Klarna that had an API error and display them on the WooCommerce status page. This should help with getting error messages when you need to debug issues without going through the logs. These will also be in the status report that you can send to us for support tickets.
+* Enhancement   - Added a warning message if you are not using pretty permalinks for your permalinks setting in WooCommerce.
+* Enhancement   - Added translations for multiple languages for the text that is printed in Emails to customers when using Klarna as a payment method.
+* Fix           - Removed a banner from the settings page that was added incorrectly.
+* Fix           - Fixed compatibility issues with PHP 8.0 that would cause some error notices in the logs.
+
+2021-06-16 - version 2.5.1
+* Fix           - Fixed the logging of AJAX errors. Should no longer be logged as [object, Object].
+
+2021-06-16 - version 2.5.0
+* Feature       - Added support to have Klarna Payments working on a combined cart and checkout page.
+* Fix           - Fixed an issue with pay for order causing it to not work.
+* Fix           - Included wc-checkout and jquery-blockui as dependencies for our JavaScript file. If blockui was missing from the checkout page it could cause a JavaScript error.
+* Fix           - We will no longer send a request to Klarna if the cart is empty.
+
+2021-05-19 - version 2.4.4
+* Enhancement   - Remove the need for URL fragments/hashtag URL when completing the checkout process.
+
+2021-03-23 - version 2.4.3
+* Fix           - Fixed an issue causing us to send a create session before totals had been calculated. This did not break anything, but caused a request to Klarna to fail in the background.
+
+2021-03-19 - version 2.4.2
+* Fix           - Fixed an incorrectly named variable causing an error on some pages.
+
+2021-03-18 - version 2.4.1
+* Fix           - Fixed a critical error when the settings for Klarna Payments has not been saved properly.
+
+2021-03-16 - version 2.4.0
+* Enhancement   - Change how and when we do calculations and send data to Klarna. Before we did this on the JS event "updated_checkout". This has been changed to rather do it after WooCommerce does their calculations, using the action "woocommerce_after_calculate_totals".
+* Feature       - Added support for the plugin Checkout Addons due to the above change.
+* Feature       - Added a filter on the order lines sent to Klarna, "kp_wc_api_order_lines". Thank you Ernesto Ruge (github the-infinity).
+* Fix           - Removed unsupported color settings for the Klarna Payments iframe.
+
+2021-03-09 - version 2.3.2
+* Fix           - Fixed an issue with the checkout freezing trying to pay for an order and not using a Klarna payments method.
+
+2021-03-04 - version 2.3.1
+* Fix           - Fixed an issue with the checkout not being unblocked when Klarna rejected a purchase.
+
+2021-03-02 - version 2.3.0
+* Feature       - Added support for Pay for order links. You can now send payment links for orders that are created in the Admin page to customers and they can complete them through Klarna Payments. This can also be used to send previously unsuccessful orders to the customers again to have them retry the same purchase again.
+
+2021-01-27 - version 2.2.0
+* Feature       - Added support for Klarnas authentication callback. After a purchase is authenticated we schedule a check after 2 minutes to possibly complete an order where the customer was not properly returned to the checkout page from the 3DS step.
+* Enhancement   - Klarna Addons now have better support for WooCommerce Admins navigation feature. Thank you to Joshua Flowers ( github joshuatf )!
+* Enhancement   - Added additional links to support and documentation on the settings page for the payment method.
+* Enhancement   - Added translation for the "What is Klarna?" string.
+
+2020-11-10 - version 2.1.4
+* Enhancement   - Added compatibility for Smart Coupons.
+* Enhancement   - Improved coupon handling on the checkout.
+* Enhancement   - Add a default icon if we are not on the checkout page and have an icon set from Klarna.
+* Fix           - Fixed an issue with sending the wrong country code for the UK when testing credentials after saving settings.
+* Fix           - Fixed an issue that caused the customer to be redirected to a 404 page on an error in the checkout.
+
+2020-09-30 - version 2.1.3
+* Enhancement   - Added proper user-agent to test-credentials check requests.
+* Fix           - Fixed an issue with saving the incorrect value as the Klarna environment used. Caused Live orders to show as test orders in the Klarna Order management meta box.
+
+2020-09-07 - version 2.1.2
+* Enhancement   - Added compatibility with the plugin WooCommerce Gift Cards. https://woocommerce.com/products/gift-cards/
+* Fix           - Fixed so you can now hide the Klarna banner from the admin pages.
+* Fix           - Klarna banner no longer shows on all admin pages. Only the Dashboard and the Klarna Payments settings page.
+
+2020-07-28 - version 2.1.1
+* Fix           - Fixed support for Finish locale again.
+
+2020-07-02 - version 2.1.0
+* Feature       - Check if credentials are correct on saving them. If they are not an error message will be displayed with more information.
+* Feature       - Added new countries to the plugin. We have now added support for BE, ES, IT, FR, NZ.
+* Enhancement   - Updated admin page banners with a new design.
+
+2020-06-02 - version 2.0.9
+* Enhancement   - Removed fallback icons for payment methods. Could cause a timeout when we tried to verify a URL endpoint.
+* Enhancement   - Updated all API requests to have a default timeout of 10 seconds.
+* Enhancement    - Force payment category to be an array in the template. Prevents issues when updating from a 1.x version to 2.x.
+* Fix           - Prevent errors on failed requests.
+* Fix           - Removed the clearing of a snippet before logging requests. Caused errors for some people.
+
+2020-05-15 - version 2.0.8
+* Fix           - Modified redirect url set in process_payment function to improve checkout flow.
+
+2020-04-09 - version 2.0.7
+* Fix			- Added security checks to the Klarna Addons page to prevent unauthorized changes to plugins.
+
+2020-02-25 - version 2.0.6
+* Fix           - Fixed an issue with nonce calculation when creating an account on the checkout page after an order is placed.
+* Fix			- Fixed an issue regarding how we handle a WP_Error, could cause a critical error for some users.
+* Feature		- Added a setting to add Klarna information to the order confirmation email sent to a customer.
+* Enhancement   - Changed the what is Klarna URL to klarna.com
+* Enhancement   - Added the WooCommerce version to the user-agent for the api requests.
+* Enhancement   - Changed the text in the order note on a failed auth call to say Authorization instead of Payment.
+
+2020-01-22 - version 2.0.5
+* Fix           - Fixed so we are now sending iFrame options on update calls.
+* Feature		- Added support for Australia.
+
+2019-11-27 - version 2.0.4
+* Fix           - Better logic for handling null responses on update session API calls.
+* Fix           - Switched the default for customer type to be Person instead of Business.
+
+2019-11-20 - version 2.0.3
+* Fix			- Fixed a rare issue with client token being invalid if changing country from a non valid Klarna Payments country to a valid one and Klarna Payments was not the default payment method.
+* Fix           - Fixed an issue with sessions not being cleared
+* Fix           - Added round to order line shipping tax amount.
+* Enhancement   - Removed an old filter that forced phone numbers to go through. No longer needed due to new architecture.
+
+2019-11-07 - version 2.0.2
+* Fix			- Fixed an issue where Client tokens where not set correctly if KP was not set as the default gateway.
+
+2019-11-04 - version 2.0.1
+* Fix           - Properly set testmode.
+
+2019-11-04 - version 2.0.0
+* Enhancement   - Complete rewrite of the plugin structure.
+* Enhancement   - Less requests being sent to Klarna for each purchase.
+* Enhancement   - Added Canada as a supported country with CAD as the currency.
+
+2019-10-22 - version 1.9.2
+* Enhancement   - Added separate error message to order if customer leaves the iframe by them selves.
+
+2019-09-25 - version 1.9.1
+* Fix           - Added check to only add shipping to order lines if shipping is needed for the order.
+
+2019-08-13 - version 1.9.0
+* Feature       - Added support for WooCommerce Store Credit plugin.
+* Tweak         - Added console logging for Authorize ajax call.
+* Tweak         - Changed shipping reference logic for order data sent to Klarna. To be better compatible with future versions of Klarna Order Management plugin.
+* Fix           - Limit reference field sent to Klarna to 64 characters.
+
+2019-08-13 - version 1.8.4
+* Fix           - Send address data to Klarna from checkout form on load call for US stores. Plugin rewrite caused payment method iframe not to be displayed for US stores.
+
+2019-08-10 - version 1.8.3
+* Enhancement	- We now use order data for authorization calls. This prevents issues with difference in formating of adress details between create order and authorization.
+* Enhancement	- Changed the text added to the order note to "Payment rejected by Klarna" on a failed authorization calls.
+* Fix			- Fixed issue with Sofort, removed a flag that was not needed to be sent with the authorization call.
+* Fix			- Fixed an issue where billing_company field could softblock the checkout.
+* Fix			- Get currency from the order instead of the WooCommerce default.
+
+2019-07-31 - version 1.8.2
+* Fix			- Added handling for failed authorization calls.
+
+2019-07-30 - version 1.8.1
+* Enhancement	- Improved JavaScript selectors for some elements. Should increase compatibility with custom themes.
+* Enhancement	- Added a failsafe for orders not properly being placed with Klarna.
+* Fix			- Fixed issue when it comes to separate sales tax for American merchants.
+
+2019-07-23 - version 1.8.0
+* Feature		- Full rewrite of the order flow. Should now be more compatible with other plugin and themes.
+* Feature		- Improved debug logging.
+* Feature		- Added support for a lot more locales.
+* Tweak         - Updated title description for Klarna Payments settings.
+* Misc			- Cleaned up JS code. Removed unused functionality.
+
+2019-06-11 - version 1.7.0
+* Feature       - Added new Klarna Add-ons page.
+* Feature       - Added Klarna On-site Messaging & Klarna order management as available add-ons.
+
+2019-06-03 - version 1.6.5
+* Tweak			- Improved logging for debugging purpose.
+* Tweak			- Added support for Swedish locale for Finish stores.
+* Tweak         - No longer tries to send company name on a B2C purchase.
+
+2019-02-06 - version 1.6.4
+* Tweak			- Removed validation of required fields in the Payment method area. Caused an issue with Authorize.net payment gateway.
+* Tweak         - Removed the disable on the Place order button since it is no longer needed to catch invalid fields.
+* Tweak         - Changed JS library endpoint.
+* Tweak         - Added extended description to the payment method title to clarify what it does.
+
+2018-11-27 - version 1.6.3
+* Feature		- Added setting to hide "What is Klarna?" link.
+* Tweak			- Added filter wc_kp_remove_postcode_spaces to enable removing whitespace from postcode posted to Klarna.
+* Tweak			- Removed update order on visibility change.
+* Tweak			- Default customer type to b2c if setting is not saved in db.
+* Tweak			- Plugin WordPress 5.0 compatible.
+* Fix			- Added support for additional required fields (other than Woo standard) on checkout. Prevents Klarna iframe from showing before all fields are entered.
+* Fix			- Narrowed search for checkout field changes. Prevents some themes from entering infinite loop that loads the Klarna iframe.
+* Fix			- Made payment method title editable again.
+* Fix			- Add round to fees sent to Klarna.
+
+2018-10-19 - version 1.6.2
+* Enhancement 	- Changed so all payment methods have the same ID in frontend as in the factory gateway. Adds support for payment gateway based fees and similar plugins.
+* Fix 			- Fixed no tax being applied to negative fee.
+
+2018-09-25 - version 1.6.1
+* Fix		    - Fixed 409 error caused by missing Organization name field.
+* Fix		    - Better support for Switzerland.
+
+2018-09-20 - version 1.6.0
+* Feature		- Added support for B2B purchases.
+* Feature		- Added support Switzerland.
+
+2018-08-30 - version 1.5.4
+* Tweak			- Added Payment method name settings field.
+* Tweak			- Added filter wc_klarna_payments_default_checkout_fields. Makes it possible to select which checkout fields should be used when sending customer data via javascript to Klarna.
+* Tweak			- Logging improvments.
+
+2018-08-17 - version 1.5.3
+* Tweak			- Added filter kp_wc_api_request_args to be able to override order data sent to Klarna.
+* Tweak			- Added filter wc_klarna_payments_available_payment_categories to be able to override wich payment methods that should be available.
+* Tweak			- Logging improvements in klarna_payments_session_ajax_update function if request fails.
+* Tweak			- Added button for hiding Klarna banner in WP admin. Stays hidden for 6 days and then reappears again (if plugin still is in test mode).
+* Fix			- KP payment method not available on Order pay page (to avoid compatibility issues with Realex payment plugin).
+
+2018-07-23 - version 1.5.2
+* Tweak			- Add max width to payment method icons.
+* Enhancement	- Added Klarna LEAP functionality (URL's for new customer signup & onboarding).
+* Fix			- Added fallback image for 404 on payment gateway icon URL.
+
+2018-06-21 - version 1.5.1
+* Tweak			- Payment gateway icons now fetched from Klarnas CDN.
+
+2018-06-08 - version 1.5.0
+* Feature		- Switches to Klarnas new /payments endpoint. Displays each Klarna payment method as its own payment option in checkout.
+* Feature		- Added support for wp_add_privacy_policy_content (for GDPR compliance). More info: https://core.trac.wordpress.org/attachment/ticket/43473/PRIVACY-POLICY-CONTENT-HOOK.md.
+* Tweak			- Switches to $product->get_name() for Klara order line name.
+* Tweak			- Adds Klarna dashboard banners and settings page sidebar.
+* Tweak			- Added PHP version and Krokedil to user agent.
+* Tweak			- Only log messages if enabled in settings.
+* Tweak			- Added logging of error response in Klarna create & update session.
+* Tweak			- Added function to hide iframes when not needed.
+* Tweak			- Added action klarna_payments_template to template. Action used in plugin to maybe create or update session.
+* Fix			- Changes the check in set_klarna_country(). No longer uses is_checkout(). Just check for customer country if WC_Customer exist.
+
+2018-01-29 - version 1.4.2
+* Fix           - Cleans up translation strings.
+* Enhancement   - process_payment method refactoring.
+
+2018-01-25 - version 1.4.1
+* Fix           - Fixes WC 3.3 notices.
+* Tweak         - Stores Klarna order transaction ID as soon as possible.
+* Tweak         - Adds "can't edit order" admin note.
+
+= 1.0 =
 * Initial release.
+
+== Upgrade Notice ==
+
+= 3.5.4 =
+This version fixes a critical error due to undefined method call. Upgrade immediately

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,0 +1,974 @@
+*** Klarna for WooCommerce Changelog ***
+
+= 3.0.6 - 2025-05-27 =
+* Enhancement - Implement 3D secure check for Google Pay #3163
+* Enhancement - Add options for "Disable Credit Cards" and "Language" #3226
+* Enhancement - Improve the loading experience for the new UI #3269
+* Enhancement - Enhance the accessibility of the new Settings UI #3294
+* Enhancement - Add capture pre-conditions for card payment source #3300
+* Enhancement - Enable all/Disable all toggle next to Alternative Payment methods on Payment Methods tab #3321
+* Enhancement - Add installment notifications for Mexico store locations #3404, #3405
+* Fix - Various issues for Mexico store locations during onboarding & plugin configuration #3403
+* Fix - APFS plugin triggers incorrect renewal date for simple products as subscriptions #3272
+* Fix - PayPal Smart Button incompatible with WooCommerce Subscription Switching #3291
+* Fix - Fastlane gateway visible on Pay for Order page #3293
+* Fix - Pay Later Messaging configurator preview alignment #3305
+* Fix - Product editing screen for variable products unresponsive (PayPal Subscriptions API error) #3311
+* Fix - Update selector for hiding express checkout #3318
+* Fix - 'Ignoring unknown key' console warnings when modifying payment gateway state #3322
+* Fix - Ratepay Payment Option Not Available for Unassembled Product Bundles #3325
+* Fix - "Disable Specific credit cards" shows "Select" as a possible value #3342
+* Fix - Stripe not visible at checkout when PayPal Subscriptions API is enabled #3343
+* Fix - Ensure correct ACDC behavior for non-ACDC countries (e.g., Vietnam) #3351
+* Fix - ACDC payments for Subscriptions failing at checkout for new users #3355
+* Fix - BCDC not enabled by default when cards selected during onboarding #3366
+* Fix - Block checkout - Address form missing after payment on Product and Cart pages #3371
+* Fix - Payments with Debit & Credit Cards failing #3376
+* Fix - PayPalGateway::process_payment on completed order leads to order failure #3374
+* Fix - New settings UI background color impacted by WooCommerce 9.9+ #3407
+* Fix - Can not save payments if subscriptions is not selected when onboarding #3408
+
+= 3.0.5 - 2025-04-23 =
+* Fix - Onboarding screen blank when WooPayments plugin is active #3312
+
+= 3.0.3 - 2025-04-08 =
+* Fix - BN code was set before the installation path was initialized #3309
+* Fix - Things to do next referenced Apple Pay while in branded-only mode #3308
+* Fix - Disabled payment methods were not hidden in reactified WooCommerce Payments settings tab #3290
+
+= 3.0.2 - 2025-04-03 =
+* Enhancement - Check the branded-only flag when settings-UI is loaded the first time #3278
+* Enhancement - Implement a Cache-Flush API #3276
+* Enhancement - Disable the mini-cart location by default #3284
+* Enhancement - Remove branded-only flag when uninstalling PayPal Payments #3295
+* Fix - Welcome screen lists "all major credit/debit cards, Apple Pay, Google Pay," in branded-only mode #3281
+* Fix - Correct heading in onboarding step 4 in branded-only mode #3282
+* Fix - Hide the payment methods screen for personal user in branded-only mode #3286
+* Fix - Enabling Save PayPal does not disable Pay Later messaging #3288
+* Fix - Settings UI: Fix Feature button links #3285
+* Fix - Create mapping for the 3d_secure_contingency setting #3262
+* Fix - Enable Fastlane Watermark by default in new settings UI #3296
+* Fix - Payment method screen is referencing credit cards, digital wallets in branded-only mode #3297
+
+= 3.0.1 - 2025-03-26 =
+* Enhancement - Include Fastlane meta on homepage #3151
+* Enhancement - Include Branded-only plugin configuration for certain installation paths
+* Enhancement - Include UI status in system report #3248
+* Enhancement - Minor enhancements in new UI scrolling & highlighting behavior #3240
+* Fix - "Warning: Class 'WooCommerce\PayPalCommerce\Vendor\Stringable' not found" after 3.0.0 update #3235
+* Fix - ACDC does not work on the Classic Checkout when using the new UI #3219
+* Fix - "Send only" country banner not displayed in the new UI #3236
+* Fix - Typo in welcome screen #3258
+* Fix - onboarding.js file from old UI enqueued in new UI #3263
+* Fix - Onboarding in new UI with personal account does not hide all ineligible features #3254
+* Fix - ACDC not defaulting on for eligible merchants after onboarding with Expanded Checkout selection #3250
+* Fix - “Failed to fetch onboarding URL” error when onboarding with Subscriptions selected from non-Vault region #3242
+* Fix - Fastlane SDK token requested when Fastlane is disabled #3009
+* Fix - Subscription renewal payment via ACDC may fail in some cases due to 3D Secure #3098
+* Fix - Error: _load_textdomain_just_in_time Called Incorrectly when running docker compose #3172
+* Fix - Shipping callback not loading for guest users in some scenarios #3169
+* Fix - Phone number not saved in WC order when using Pay Now experience #3160
+* Fix - Phone number not pre-populated on Checkout block in continuation mode #3160
+* Fix - "Unfortunately, your credit card details are not valid" shown with actually valid card during checkout with invalid postcode. #3067
+* Fix - Incorrect Subscription Cancellation Handling with PayPal Subscriptions #3046
+* Tweak - Added PayPal as contributor #3259
+
+= 3.0.0 - 2025-03-17 =
+* Enhancement - Redesigned settings UI for new users #2908
+* Enhancement - Enable Fastlane by default on new store setups when eligible #3199
+* Enhancement - Enable support for advanced card payments and features for Hong Kong & Singapore #3089
+* Fix - Dependency conflict with more recent psr/log versions on PHP8+ #2993
+* Fix - PayPal Checkout Gateway subscription migration layer not renewing subscriptions #2699
+* Fix - Fatal error when gateway settings initialized too early by third-party plugin #2766
+* Fix - Next Payment date for Subscriptions not updating when processing a PayPal Subscriptions renewal order #2959
+* Fix - Changing the subscription payment method to ACDC triggers error #2891
+* Fix - Standard Card button not appearing in standalone gateway for free trial subscription products #2935
+* Fix - Validation error when using Trustly payment method #3031
+* Fix - Error in continuation mode due to wrong gateway selection on Checkout block #2996
+* Fix - Error in error in PayLaterConfigurator #2989
+* Tweak - Removed currency requirement for Vault v3 #2919
+* Tweak - Update plugin author from WooCommerce to PayPal
+
+= 2.9.6 - 2025-01-06 =
+* Fix - NOT_ENABLED_TO_VAULT_PAYMENT_SOURCE on PayPal transactions when using ACDC Vaulting without PayPal Vault approval #2955
+* Fix - Express buttons for Free Trial Subscription products on Block Cart/Checkout trigger CANNOT_BE_ZERO_OR_NEGATIVE error #2872
+* Fix - String translations not applied to Card Fields on Block Checkout #2934
+* Fix - Fastlane component included in script when Fastlane is disabled #2911
+* Fix - Zero amount line items may trigger CANNOT_BE_ZERO_OR_NEGATIVE error after rounding error #2906
+* Fix - “Save changes” is grey and unclickable when switching from Sandbox to Live #2895
+* Fix - plugin queries variations when button/messaging is disabled on single product page #2896
+* Fix - Use get_id instead of get_order_number on setting custom_id (author @0verscore) #2930
+* Enhancement - Improve fraud response order notes for Advanced Card Processing transactions #2905
+* Tweak - Update the minimum plugin requirements to WordPress 6.5 & WooCommerce 9.2 #2920
+
+= 2.9.5 - 2024-12-10 =
+* Fix - Early translation loading triggers `Function _load_textdomain_just_in_time was called incorrectly.` notice #2816
+* Fix - ACDC card fields not loading and payment not successful when Classic Checkout Smart Button Location disabled #2852
+* Fix - ACDC gateway does not appear for guests when is Fastlane enabled and a subscription product is in the cart #2745
+* Fix - "Voide authorization" button does not appear for Apple Pay/Google Pay orders when payment buttons are separated #2752
+* Fix - Additional payment tokens saved with new customer_id #2820
+* Fix - Vaulted payment method may not be displayed in PayPal button for return buyer #2809
+* Fix - Conflict with EasyShip plugin due to shipping methods loading too early #2845
+* Fix - Restore accidentally removed ACDC currencies #2838
+* Enhancement - Native gateway icon for PayPal & Pay upon Invoice gateways #2712
+* Enhancement - Allow disabling specific card types for Fastlane #2704
+* Enhancement - Fastlane Insights SDK implementation for block Checkout #2737
+* Enhancement - Hide split local APMs in Payments settings tab when PayPal is not enabled #2703
+* Enhancement - Do not load split local APMs on Checkout when PayPal is not enabled #2792
+* Enhancement - Add support for Button Options in the Block Checkout for Apple Pay & Google Pay buttons #2797 #2772
+* Enhancement - Disable “Add payment method” button while saving ACDC payment #2794
+* Enhancement - Sanitize soft_descriptor field #2846 #2854
+
+= 2.9.4 - 2024-11-11 =
+* Fix - Apple Pay button preview missing in Standard payment and Advanced Processing tabs #2755
+* Fix - Set "Sold individually" only for subscription connected to PayPal #2710
+* Fix - Ensure Google Pay button does not appear for subscriptions #2718
+* Fix - PayPal Subscriptions API renewal order not created in WooCommerce #2612
+* Fix - Apple Pay button disappears on Classic Checkout #2722
+* Fix - Google Pay and Apple Pay as separate gateways does not show button when checkout remove from button locations #2756
+* Fix - Add GW refund support for Apple Pay #2746
+* Fix - PayPal Subscriptions cancel and suspend from Subscriptions list page does not work #2632
+* Fix - Displaying of HTML tags in product title on choosing a product for tracking (2801) #2701
+* Fix - Payment with OXXO cause continuation state for next payment #2702
+* Fix - Fix problems with autoptimize plugin #2705
+* Fix - Missing custom field PayPal Transaction Fee for OXXO #2700
+* Enhancement - Add void button #2678
+* Enhancement - Use basic redirect gateway when checkout smart buttons disabled #2714
+* Enhancement - Receive button properties from the Checkout Block #2448
+* Enhancement - Run PPEC\DeactivateNote query only in backend #2719
+* Enhancement - Prevent plugin use for "Send only" countries #2721
+* Enhancement - Do not add pay later button in editor #2570
+* Enhancement - Axo: Remove the submit button when Fastlane is disabled #2720
+* Enhancement - Sync the PayPal product page button state to Apple/Google Pay buttons, show alerts #2742
+
+= 2.9.3 - 2024-10-15 =
+* Fix - Multi-currency support #2667
+* Fix - "0.00" amount in Google Pay for virtual products #2636
+* Fix - Unsuccessfully payment from product page with Apple Pay button #2643
+* Fix - Button Unlinking PayPal Subscriptions plan does not showing for simple subscription #2618
+* Fix - Declare tokenization for ACDC only when vaulting enabled #2581
+* Fix - Classic shortcode block type checks #2608
+* Fix - PUI error in editor #2580
+* Fix - Add a new namespaced script loader for ApplePay #2682 #2675
+* Fix - Axo Block: Fix the Fastlane modal info message text overflow issue #2663
+* Fix - Add Custom Placeholder Handling when rendering the card fields #2651
+* Fix - Use the PayPal icons instead of WC ones #2639
+* Fix - Google Pay preview config and style #2661
+* Fix - Improve context detection #2631
+* Fix - Check that get_the_ID is valid before using #2573
+* Fix - Axo Block: Always display the Fastlane watermark in the includeAdditionalInfo mode #2690
+* Fix - Axo Block: Display card fields for authenticated cardless profiles #2672
+* Fix - Google Pay: Fix button preview in the editor #2688
+* Fix - ACDC gateway not visible on the block Checkout for logged-out users #2693
+* Enhancement - Enhancement - Add Fastlane support for Checkout block
+* Enhancement - Multiple calls to POST /v1/oauth2/token?grant_type=client_credentials&response_type=id_token #2671
+* Enhancement - Fastlane update shipping options & taxes when changing address #2665
+* Enhancement - Axo: Remove Axo from the Checkout block in the editor and add an ACDC card preview #2662
+* Enhancement - Set email when creating order for express payment #2577
+
+= 2.9.2 - 2024-10-01 =
+* Enhancement - Add Fastlane support for Classic Checkout
+* Fix - Fatal error when Pay Later messaging configurator was disabled with a code snippet
+
+= 2.9.1 - 2024-09-24 =
+* Fix - Improve card fields hiding #2574
+* Fix - Google Pay: Shipping callback not calculating totals correctly on Single Product page #2513
+* Fix - Fix shipping callback condition in status report #2578
+* Fix - Can't Disconnect Account #2539
+* Fix - Google Pay billing data without shipping callback #2525
+* Fix - Standard payment tab - Google Pay and Apple Pay button - Shape from one location is applied to all until saving changes #2419
+* Enhancement - Allow to override the list of Pay Later supported countries #2563
+* Enhancement - Add more feature statuses into system report #2550
+* Enhancement - Use SVG for APM gateway icons #2509
+* Enhancement - Add inline notice to inform users about ACDC block Checkout support if the store uses a Classic Checkout setup #2422
+* Enhancement - Remove leftover console.log #2589
+* Enhancement - Require PHP 7.4+, WP 6.3+, WC 6.9+ #2556
+* Enhancement - Modularity module migration #1944
+* Enhancement - Keep only 5 tags in readme.txt #2562
+* Enhancement - Select ACDC by default during onboarding for China store locations #2619
+* Enhancement - Add title, description and gatewayId to the express payment method #2566
+
+= 2.9.0 - 2024-09-02 =
+* Fix - Fatal error in Block Editor when using WooCommerce blocks #2534
+* Fix - Can't pay from block pages when the shipping callback is enabled and no shipping methods defined #2429
+* Fix - Various Google Pay button fixes #2496
+* Fix - Buying a free trial subscription with ACDC results in a $1 charge in the API call #2465
+* Fix - Problem with Google Pay and Apple Pay button placement on Pay for Order page #2542
+* Fix - When there isn't any shipping option for the address the order is still created from classic cart #2437
+* Fix - Patch the order with no shipping methods, instead of throwing an error #2435
+* Enhancement - Separate Apple Pay button for Classic Checkout #2457
+* Enhancement - Remove AMEX support for ACDC when store location is set to China #2526
+* Enhancement - Inform users of Pay Later messaging configuration when Pay Later wasn't recently enabled #2529
+* Enhancement - Update ACDC signup URLs #2475
+* Enhancement - Implement country based APMs via Orders API #2511
+* Enhancement - Update PaymentsStatusHandlingTrait.php (author @callmeahmedr) #2523
+* Enhancement - Disable PayPal Shipping callback by default #2527
+* Enhancement - Change Apple Pay and Google Pay default button labels to plain #2476
+* Enhancement - Add Package Tracking compatibility with DHL Shipping plugin #2463
+* Enhancement - Add support for WC Bookings when skipping checkout confirmation #2452
+* Enhancement - Remove currencies from country-currency matrix in card fields module #2441
+
+= 2.8.3 - 2024-08-12 =
+* Fix - Google Pay: Prevent field validation from being triggered on checkout page load #2474
+* Fix - Do not add tax info into order meta during order creation #2471
+* Fix - PayPal declares subscription support when for Subscription mode is set Disable PayPal for subscription #2425
+* Fix - PayPal js files loaded on non PayPal pages #2411
+* Fix - Google Pay: Fix the incorrect popup triggering #2414
+* Fix - Add tax configurator when programmatically creating WC orders #2431
+* Fix - Shipping callback compatibility with WC Name Your Price plugin #2402
+* Fix - Uncaught Error: Cannot use object of type ...\Settings as array in .../AbstractPaymentMethodType.php (3253) #2334
+* Fix - Prevent displaying smart button multiple times on variable product page #2420
+* Fix - Prevent enabling Standard Card Button when ACDC is enabled #2404
+* Fix - Use client credentials for user tokens #2491
+* Fix - Apple Pay: Fix the shipping callback #2492
+* Enhancement - Separate Google Pay button for Classic Checkout #2430
+* Enhancement - Add Apple Pay and Google Pay support for China, simplify country-currency matrix #2468
+* Enhancement - Add AMEX support for Advanced Card Processing in China #2469
+
+= 2.8.2 - 2024-07-22 =
+* Fix - Sold individually checkbox automatically disabled after adding product to the cart more than once #2415
+* Fix - All products "Sold individually" when PayPal Subscriptions selected as Subscriptions Mode #2400
+* Fix - W3 Total Cache: Remove type from file parameter as sometimes null gets passed causing errors #2403
+* Fix - Shipping methods during callback not updated correctly #2421
+* Fix - Preserve subscription renewal processing when switching Subscriptions Mode or disabling gateway #2394
+* Fix - Remove shipping callback for Venmo express button #2374
+* Fix - Google Pay: Fix issue with data.paymentSource being undefined #2390
+* Fix - Loading of non-Order as a WC_Order causes warnings and potential data corruption #2343
+* Fix - Apple Pay and Google Pay buttons don't appear in PayPal Button stack on multi-step Checkout #2372
+* Fix - Apple Pay: Fix when shipping is disabled #2391
+* Fix - Wrong string in smart button preview on Standard Payments tab #2409
+* Fix - Don't break orders screen when there is an exception for package tracking #2369
+* Fix - Pay Later button preview is missing #2371
+* Fix - Apple Pay button layout #2367
+* Enhancement - Remove BCDC button from block Express Checkout area #2381
+* Enhancement - Extend Advanced Card Processing country eligibility for China #2397
+
+= 2.8.1 - 2024-07-01 =
+* Fix - Don't render tracking metabox if PayPal order does not belong to connected merchant #2360
+* Fix - Fatal error when the ppcp-paylater-configurator module is disabled via code snippet #2327
+* Fix - Apple Pay & Google Pay buttons no longer visible in Standard Payments button previews after moving the configuration to Advanced Card Processing tab #2325
+* Fix - Fix Smart Buttons on Elementor checkout widget #2284
+* Fix - Pay by link - Capturing order from guest user causing fatal error when Vaulting is enabled #2382
+* Fix - Enable the gateway settings JS file on connection tab #2377
+* Enhancement - Add filter for certain settings to allow gateway translation e.g. via WPML #2308
+* Enhancement - Filter for adding more contexts in can_render_dcc checker #2346
+* Enhancement - Do not request id_token for guest users #2283
+* Enhancement - Prevent multiple PayPal Subscription products in the cart if PayPal Subscription API is active #2320
+* Enhancement - Prevent script caching & minification from Litespeed Cache and W3 Total Cache plugins #2316
+* Enhancement - Remove Giropay references due to deprecation #2379
+
+= 2.8.0 - 2024-06-11 =
+* Fix - Calculate totals after adding shipping to include taxes #2296
+* Fix - Package tracking integration throws error in 2.7.1 #2289
+* Fix - Make PayPal Subscription products unique in cart #2265
+* Fix - PayPal declares subscription support when merchant not enabled for Reference Transactions #2282
+* Fix - Google Pay and Apple Pay Settings button from Connection tab have wrong links #2273
+* Fix - Smart Buttons in Block Checkout not respecting the location setting (2830) #2278
+* Fix - Disable Pay Upon Invoice if billing/shipping country not set #2281
+* Fix - Critical error on pay for order page when we try to pay with ACDC gateway #2321
+* Enhancement - Enable shipping callback for WC subscriptions #2259
+* Enhancement - Disable the shipping callback for "venmo" when vaulting is active #2269
+* Enhancement - Improve "Could not retrieve order" error message #2271
+* Enhancement - Add block Checkout compatibility to Advanced Card Processing #2246
+
+= 2.7.1 - 2024-05-28 =
+* Fix - Ensure package tracking data is sent to original PayPal transaction #2180
+* Fix - Set the 'Woo_PPCP' as a default value for data-partner-attribution-id #2188
+* Fix - Allow PUI Gateway for refund processor #2192
+* Fix - Notice on newly created block cart checkout #2211
+* Fix - Apple Pay button in the editor #2177
+* Fix - Allow shipping callback and skipping confirmation page from any express button #2236
+* Fix - Pay Later messaging configurator sometimes displays old settings after saving #2249
+* Fix - Update the apple-developer-merchantid-domain-association validation strings for Apple Pay #2251
+* Fix - Enable the Shipping Callback handlers #2266
+* Enhancement - Use admin theme color #1602
+
+= 2.7.0 - 2024-04-30 =
+* Fix - Zero sum subscriptions cause CANNOT_BE_ZERO_OR_NEGATIVE when using Vault v3 #2152
+* Fix - Incorrect Pricing Issue with Variable Subscriptions in PayPal Subscriptions Mode #2156
+* Fix - Wrong return_url in multisite setup when using subdomains #2157
+* Fix - Fix the fundingSource is not defined error on Block Checkout #2185
+* Enhancement - Add the data-page-type attribute for JS SDK #2161
+* Enhancement - Save Card Last Digits in order meta for Advanced Card Payments #2149
+* Enhancement - Refactor the Pay Later Messaging block and add dedicated Cart/Checkout blocks #2153
+* Enhancement - "Next Payment" status not updated when using PayPal Subscriptions #2091
+* Enhancement - Optimize default settings for new store configurations #2158
+* Enhancement - Improve tooltip information for tagline #2154
+* Enhancement - Improve error message on certain exceptions #1354
+* Enhancement - Cart Pay Later block: Change the default insert position #2179
+* Enhancement - Messages Bootstrap: Add a render retry functionality #2181
+
+= 2.6.1 - 2024-04-09 =
+* Fix - Payment tokens fixes and adjustments #2106
+* Fix - Pay upon Invoice: Add input validation to Experience Context fields #2092
+* Fix - Disable markup in get_plugin_data() returns to fix an issue with wptexturize() #2094
+* Fix - Problem changing the shipping option in block pages #2142
+* Fix - Saved payment token deleted after payment with another saved payment token #2146
+* Enhancement - Pay later messaging configurator improvements #2107
+* Enhancement - Replace the middleware URL from connect.woocommerce.com to api.woocommerce.com/integrations #2130
+* Enhancement - Remove all Sofort references as it has been deprecated #2124
+* Enhancement - Improve funding source names #2118
+* Enhancement - More fraud prevention capabilities by storing additional data in the order #2125
+* Enhancement - Update ACDC currency eligibility for AMEX #2129
+* Enhancement - Sync shipping options with Venmo when skipping final confirmation on Checkout #2108
+* Enhancement - Card Fields: Add a filter for the CVC field and update the placeholder to match the label #2089
+* Enhancement - Product Title: Sanitize before sending to PayPal #2090
+* Enhancement - Add filter for disabling permit_multiple_payment_tokens vault attribute #2136
+* Enhancement - Filter to hide PayPal email address not working on order detail #2137
+
+= 2.6.0 - 2024-03-20 =
+* Fix - invoice_id not included in API call when creating payment with saved card #2086
+* Fix - Typo in SCA indicators for ACDC Vault transactions #2083
+* Fix - Payments with saved card tokens use Capture intent when Authorize is configured #2069
+* Fix - WooPayments multi-currency causing currency mismatch error on Block Cart & Checkout pages #2054
+* Fix - "Must pass createSubscription with intent=subscription" error with PayPal Subscriptions mode #2058
+* Fix - "Proceed to PayPal" button displayed for Free trial PayPal Subscription products when payment token is saved #2041
+* Fix - ACDC payments with new credit card may fail when debugging is enabled (JSON malformed by warning) #2051
+* Enhancement - Add Pay Later Messaging block #1897
+* Enhancement - Submit the form instead of refreshing the page to show the save notice #2081
+* Enhancement - Integrate pay later messaging block with the messaging configurator #2080
+* Enhancement - Reauthorize authorized payments #2062
+* Enhancement - Do not handle VAULT.PAYMENT-TOKEN.CREATED webhook for Vault v3 #2079
+* Enhancement - Improve the messaging configurator styles #2053
+* Enhancement - Ensure PayPal Vaulting is not selected as Subscriptions Mode when Reference Transactions are disabled #2057
+* Enhancement - Pay later messaging configurator & messaging block adjustments #2096
+
+= 2.5.4 - 2024-02-27 =
+* Fix - Cannot enable Apple Pay when API credentials were manually created #2015
+* Fix - Cart simulation type error #1943
+* Enhancement - Apple Pay recurring payments #1986
+* Enhancement - Real Time Account Updater (RTAU) integration #2027
+* Enhancement - Prepare the SKU for sending to PayPal #2033
+* Enhancement - Store the Card Brand in Address Verification Result instead of 3DS authentication result #2026
+* Enhancement - Update country eligibility for AdvancedCard Processing, Apple Pay, Google Pay #2019
+* Enhancement - Disable PayPal Vaulting setting instead of hiding it when Reference Transactions not available #2029
+* Enhancement - Store three d secure enrollment status and authentication status responses in wc order #1980
+* Enhancement - Add more checks to prevent "PayPal order ID not found" errors #2038
+* Enhancement - Disable messaging configurator when vault is enabled #2042
+* Feature preview - Pay Later Messaging configurator #1924
+
+= 2.5.3 - 2024-02-06 =
+* Fix - Free trial subscription products using PayPal Vaulting when PayPal Subscriptions configured as Subscriptions Mode #1979
+* Fix - Pay by link - Germany - PayPal buttons are not visible on Pay for order page #2014
+* Enhancement - Extend Apple Pay, Google Pay, Vault v3 (& RTAU) country availability #1992
+* Enhancement - Enable card fields for ACDC and Vault v3 supported countries/currencies #2007
+* Enhancement - Update ACDC supported currencies list #1991
+* Enhancement - Check if the $wpdb->wc_orders exists before query #1996
+* Enhancement - Remove MercadoPago from disable funding sources #2003
+* Enhancement - Improve onboarding notice text #2002
+
+= 2.5.2 - 2024-02-01 =
+* Fix - NOT_ENABLED_TO_VAULT_PAYMENT_SOURCE error for merchants without reference transactions #1984
+* Fix - Fatal error in WooCommerce PayPal Payments plugin after 2.5.0 update #1985
+* Fix - Can not refund order purchased with Vault v3 Card payment #1997
+* Fix - PayPal Vaulting Subscriptions mode setting visible when merchant not enabled for Reference Transactions #1999
+* Fix - card-fields parameter included in button script despite Advanced Card Processing disabled #2005
+* Enhancement - Add setup URL for reference transactions #1964
+* Enhancement - Improve PUI performance for variable products #1950
+
+= 2.5.1 - 2024-01-24 =
+* Temporary revert Vaulting integration changes introduced in 2.5.0
+
+= 2.5.0 - 2024-01-22 =
+* Fix - WC Subscriptions change subscription payment #1953
+* Fix - GooglePay and ApplePay buttons disappear from the minicart when adding a product to the cart on the shop page #1915
+* Enhancement - Enable Vault v3 and Card Fields by default for US merchants #1967
+* Enhancement - Vault v3 WC Subscriptions integration #1920
+* Enhancement - Implement early WC validation for Hosted Card Fields #1925
+* Enhancement - Rename button locations #1946
+* Enhancement - Improve Apple Pay validation notice text #1938
+* Enhancement - Improve feature availability check UX #1941
+* Enhancement - Make all hosted card fields strings translatable #1926
+* Enhancement - PHP 8.2 deprecations #1939
+* Enhancement - Subscription support on Block Cart & Block Express Checkout #1956
+* Enhancement - Venmo Vaulting integration #1958
+* Enhancement - Add package tracking support for UK #1970
+
+= 2.4.3 - 2024-01-04 =
+* Fix - PayPal Subscription initiated without a WooCommerce order #1907
+* Fix - Block Checkout reloads when submitting order with empty fields #1904
+* Fix - "Send checkout billing and shipping data to Apple Pay" displayed when Apple Pay is disabled #1883
+* Fix - "Order does not contain intent" error for ACDC renewals when triggering 3D Secure #1888
+* Fix - PayPal Subscriptions button greyed out (inactive) on Checkout page for variable subscription products #1914
+* Enhancement - Add button to reload feature eligibility status from Connection tab #1902
+* Enhancement - Apple Pay validation message improvements #1901
+* Enhancement - Improve support for Classic Cart & Classic Checkout blocks #1894
+* Enhancement - Ensure uniform button appearance for PayPal, Google Pay, and Apple Pay buttons #1900
+* Enhancement - remove string translations for package tracking carriers from repository #1885
+* Enhancement - Incorrect margins when PayPal buttons are rendered as separate gateways. #1908
+* Enhancement - Improved button spacing when Apple Pay is enabled but current buyer is not eligible #1922
+* Feature preview - Save payment methods (Vault v3) integration  #1779
+
+= 2.4.2 - 2023-12-04 =
+* Fix - Action callback arguments count in ShipStation tracking integration #1841
+* Fix - Google Pay scripts loading on unrelated admin pages #1834
+* Fix - Do not ignore disabled APMs list in blocks #1865
+* Fix - Display Package Tracking metabox below Order actions when HPOS is active #1850
+* Fix - ApplePay use checkout form data to update shipping and billing #1832
+* Fix - Fix Apple Pay CSS #1872
+* Enhancement - Allow redirect to PayPal with "Place order" button if smart buttons failed to load #1840 #1870
+* Enhancement - Extend list of supported countries for Package Tracking v2 integration #1848
+* Enhancement - Improve Block Theme support for Pay Later messaging #1855
+* Enhancement - Render block buttons separately and add block style settings #1858
+* Enhancement - Enable Block Cart and Block Express Checkout button locations by default #1852
+* Enhancement - Improve single product page button placement with Block themes #1847
+* Enhancement - Remove the Home location from default enabled Pay Later messaging locations #1856
+* Enhancement - Chrome browser detected as eligible for Apple Pay on settings page #1828
+* Enhancement - Hide Apple Pay & Google Pay for subscription type products #1835
+* Enhancement - Add Standard Card Button gateway styling settings & preview #1827
+* Feature preview - Upgrade to new Hosted Card Fields for Advanced Card Processing #1843
+
+= 2.4.1 - 2023-11-14 =
+* Fix - Error "PayPal order ID not found in meta" prevents automations from triggering when buying subscription via third-party payment gateway #1822
+* Fix - Card button subscription support declaration #1796
+* Fix - Pay Later messaging disappears when updating shipping option on cart page #1807
+* Fix - Apple Pay payment from single product may fail after changing shipping options in Apple Pay payment sheet #1810
+* Enhancement - Extend list of supported countries for Advanced Card Processing #1808
+* Enhancement - Extend Apple Pay/Google Pay country eligibility to Italy #1811
+* Enhancement - Override language used to display PayPal buttons #600
+* Enhancement - Apple Pay button preview #1824
+* Enhancement - Add Apple Pay & Google Pay logos on the onboarding page #1823
+* Enhancement - Improve Apple Pay compatibility with variable products on single product page #1803
+* Enhancement - Apple Pay domain registration & browser eligibility check #1821
+* Enhancement - Package Tracking compatibility with WooCommerce Shipping & ShipStation for WooCommerce #1813
+* Enhancement - Fill form when continuation in block #1794
+* Enhancement - Display Shop location Pay Later messaging on product category pages #1809
+* Enhancement - Present apple-developer-merchantid-domain-association file only when Apple Pay is enabled #1818
+* Enhancement - Improve Apple Pay compatibility on Pay for Order page #1815
+* Enhancement - Display Pay Later messages before the payment methods on the Pay for Order page #1814
+* Enhancement - Handle undefined array key warnings on PHP 8.1 #1804
+
+= 2.4.0 - 2023-10-31 =
+* Fix - Mini-Cart Bug cause of wrong DOM-Structure in v2.3.1 #1735
+* Fix - ACDC disappearing after plugin updates #1751
+* Fix - Subscription module hooks #1748
+* Fix - Ensure PayPal Subscriptions API products description is 1-127 characters #1738
+* Fix - Add validation on the Plan Name field to not accept a blank value #1754
+* Enhancement - Improve Pay Later messages and add Shop, Home locations #1770
+* Enhancement - Use api-m PayPal API URLs #1740
+* Enhancement - Google Pay Settings improvements #1719
+* Enhancement - Apple Pay transaction improvements #1767
+* Enhancement - Change default ACDC title #1750
+* Enhancement - Cart simulation improvements #1753
+* Enhancement - Billing schedule fields not greyed out when PayPal Subscriptions product is connected #1755
+* Enhancement - Check validation errors when submitting in block #1528
+* Enhancement - Improve handling of server error when submitting block #1785
+* Enhancement - Extend Apple Pay country eligibility #1781
+* Enhancement - Apple Pay validation notice improvements #1783
+* Enhancement - Apple Pay payment process issues #1789
+* Enhancement - Disable the tracking if payment is not captured #1780
+* Enhancement - Place order button remains - Could not retrieve order #1786
+* Enhancement - Google Pay for variable product greyed out but clickable #1788
+* Enhancement - Merchant credential validation & remove PAYEE object #1795
+
+= 2.3.1 - 2023-09-26 =
+* Fix - Fatal error when saving product while WooCommerce Subscriptions plugin is not active #1731
+* Fix - Validate tracking data only for add/update Package Tracking #1729
+* Fix - Disable Package Tracking for order if transaction ID doesn't exist #1727
+
+= 2.3.0 - 2023-09-26 =
+* Fix - Plus sign in PayPal account email address gets converted to space #771
+* Fix - Payment method dropdown option label on edit order screen for ppcp-gateway option displaying wrong name #1639
+* Fix - WooCommerce Bookings products don't remain in Cart as a guest when PayPal button active on single product #1645
+* Fix - Since version > 2.2.0 the PayPal Checkout button on single product pages does not redirect anymore #1664
+* Fix - PayPal fee and PayPal Payout do not change on order if we do partial refund #1578
+* Fix - Order does not contain intent error when using ACDC payment token while buyer is not present #1506
+* Fix - Error when product description linked with a PayPal subscription exceeds 127 characters #1700
+* Fix - $_POST uses the wrong key to hold the shipping method #1652
+* Fix - WC Payment Token created multiple times when webhook is received #1663
+* Fix - Subtotal mismatch line name shows on Account settings page when merchant is disconnected #1702
+* Fix - Warning prevents payments on Pay for Order page when debugging is enabled #1703
+* Fix - paypal-overlay-uid_ blocks page after closing PayPal popup on Pay for Order page | Terms checkbox validation fails on Pay for Order page #1704
+* Enhancement - Add support for HPOS for tracking module #1676
+* Enhancement - Billing agreements endpoint called too frequently for Reference Transactions check #1646
+* Enhancement - Do not declare subscription support for PayPal when only ACDC vaulting #1669
+* Enhancement - Apply Capture On Status Change only when order contains PayPal payment method #1595
+* Enhancement - Do not use transient expiration longer than one month to support memcached #1448
+* Enhancement - By disconnecting or disabling the plugin the connection should clear the Onboarding links from cache #1668
+* Enhancement - Upgrade tracking integration #1562
+* Enhancement - Include url & image_url in create order call #1649
+* Enhancement - Add compat layer for Yith tracking #1656
+* Enhancement - Improve invalid currency backend notice (1926) #1588
+* Enhancement - Hide ACDC footer frame via CSS to avoid empty space #1613
+* Enhancement - Compatibility with WooCommerce Product Add-Ons plugin #1586
+* Enhancement - Remove "no shipment" message after adding tracking #1674
+* Enhancement - Improve error & success validation messages #1675
+* Enhancement - Compatibility with third-party "Product Add-Ons" plugins #1601
+* Enhancement - PayPal logo flashes when switching between tabs #1345
+* Enhancement - Include url & image_url in create order call #1649
+* Enhancement - Include item_url & image_url to tracking call #1712
+* Enhancement - Update strings for tracking metabox #1714
+* Enhancement - Validate email address API credentials field #1691
+* Enhancement - Set payment method title for order edit page only if our gateway #1661
+* Enhancement - Fix missing Pay Later messages in cart + refactoring #1683
+* Enhancement - Product page PP button keep loading popup - "wc_add_to_cart_params is not defined" error in WooCommerce #1655
+* Enhancement - Remove PayPal Subscriptions API feature flag #1690
+* Enhancement - Don't send image_url when it is empty #1678
+* Enhancement - Subscription support depending on Vaulting setting instead of subscription mode setting #1697
+* Enhancement - Wrong PayPal subscription id on vaulted subscriptions #1699
+* Enhancement - Remove payment vaulted checker functionality (2030) #1711
+* Feature preview - Apple Pay integration #1514
+* Feature preview - Google Pay integration #1654
+
+= 2.2.2 - 2023-08-29 =
+* Fix - High rate of auth voids on vaulted subscriptions for guest users #1529
+* Enhancement - HPOS compatibility issues #1594
+* Feature preview - PayPal Subscriptions API fixes and improvements #1600 #1607
+
+= 2.2.1 - 2023-08-24 =
+* Fix - One-page checkout causes mini cart not showing the PP button on certain pages #1536
+* Fix - When onboarding loading the return_url too fast may cause the onboarding to fail #1565
+* Fix - PayPal button doesn't work for variable products on product page after recent 2.2.0 release #1533
+* Fix - Send payee_preferred correctly for instant payments #1489
+* Fix - Auto-disabled ACDC vaulting after updating to 2.1.0 #1490
+* Fix - PayPal Payments serializing formData of array inputs #1501
+* Fix - Buttons not working on single product page for WooCommerce Bookings product #1478
+* Enhancement - PayPal Later message price amount doesn't update dynamically #1585
+* Enhancement - Improve WC order creation in webhook #1530
+* Enhancement - Refactor hosted fields for early card detection #1554
+* Enhancement - Pay Later button and message get hidden when product/cart/checkout value is outside of range #1511
+* Enhancement - Add link to manual credential docs #1430
+* Enhancement - Validate Merchant ID field format when saving settings #1509
+* Enhancement - Include soft descriptor for card's activity #1427
+* Enhancement - Update Pay Later amount on the cart page and checkout when total changes #1441
+* Enhancement - Log Subscription Mode configuration in system report #1507
+* Enhancement - HPOS compatibility issues #1555
+* Feature preview - PayPal Subscriptions API fixes and improvements #1443
+
+= 2.2.0 - 2023-07-17 =
+* Fix - Improve handling of APM payments when buyer did not return to Checkout #1233
+* Fix - Use order currency instead of shop currency on order-pay page #1363
+* Fix - Do not show broken card button gateway when no checkout location #1358
+* Fix - Smart buttons not greyed out/removed on single product when deselecting product variation #1469
+* Fix - Type error with advanced columns pro #1367
+* Fix - Undefined array key 0 when checking $retry_errors in process_payment method #1375
+* Fix - Advanced Card Processing gateway becomes invisible post-plugin update unless admin pages are accessed once #1432
+* Fix - Incompatibility with WooCommerce One Page Checkout (or similar use cases) in Version 2.1.0 #1473
+* Fix - Prevent Repetitive Token Migration and Database Overload After 2.1.0 Update #1461
+* Fix - Onboarding from connection page with CSRF parameter manipulates email and merchant id fields #1502
+* Fix - Do not complete non-checkout button orders via webhooks #1513
+* Enhancement - Remove feature flag requirement for express cart/checkout block integration #1483
+* Enhancement - Add notice when shop currency is unsupported #1433
+* Enhancement - Improve ACDC error message when empty fields #1360
+* Enhancement - Do not exclude free items #1362
+* Enhancement - Trigger WC checkout_error event #1384
+* Enhancement - Update wording in buttons previews #1408
+* Enhancement - Filter to conditionally block the PayPal buttons #1485
+* Enhancement - Display funding source on the admin order page #1450
+* Enhancement - Update system report plugin status for Vaulting #1471
+* Enhancement - Revert Elementor Pro Checkout hook compatibility #1482
+
+= 2.1.0 - 2023-06-13 =
+* Fix - Performance issue #1182
+* Fix - Webhooks not registered when onboarding with manual credentials #1223
+* Fix - Boolean false type sent as empty value when setting cache #1313
+* Fix - Ajax vulnerabilities #1411
+* Enhancement - Save and display vaulted payment methods in WC Payment Token API #1059
+* Enhancement - Cache webhook verification results #1379
+* Enhancement - Refresh checkout totals after validation if needed #1294
+* Enhancement - Improve Divi and Elementor Pro compatibility #1254
+* Enhancement - Add MX and JP to ACDC #1415
+* Enhancement - Add fraudnet script to SGO filter #1366
+* Feature preview - Add express cart/checkout block #1346
+* Feature preview - Integrate PayPal Subscriptions API #1217
+
+= 2.0.5 - 2023-05-31 =
+* Fix - Potential invalidation of merchant credentials #1339
+
+= 2.0.4 - 2023-04-03 =
+* Fix - Allow Pay Later in mini-cart #1221
+* Fix - Duplicated auth error when credentials become wrong #1229
+* Fix - Webhook issues when switching sandbox, and delete all webhooks when unsubscribing #1239
+* Fix - High volume of traffic from merchant-integrations endpoint #1273
+* Fix - Add content type json to all fetch ajax endpoints #1275
+* Enhancement - Remove shortcodes from description #1226
+* Enhancement - Handle price suffix with price for product button check #1234
+* Enhancement - Show funding source as payment method #1220
+* Enhancement - Change "Enabled" to "Available" in status text #1237
+* Enhancement - Programmatically capturing/voiding authorized payments #590
+
+= 2.0.3 - 2023-03-14 =
+* Fix - `DEVICE_DATA_NOT_AVAILABLE` error message when FraudNet is enabled #1177
+* Fix - Redirect to connection tab after manual credentials input #1201
+* Fix - Asking for address fields in checkout when not using them #1089
+* Fix - Validate before free trial #1170
+* Fix - Validate new user creation #1131
+* Fix - After Updating to 2.0.2, Site Health reports REST API error #1195
+* Fix - Do not send buyer-country for previews in live mode to avoid error #1186
+* Fix - PPEC compatibility layer does not take over subscriptions #1193
+* Fix - Checkout conflict with "All products for subscriptions" plugin #629
+* Fix - Pay Later on order pay page #1214
+* Fix - High volume of traffic from merchant-integrations endpoint #1241
+* Enhancement - Save checkout form before free trial redirect #1135
+* Enhancement - Add filter for controlling the ditching of items/breakdown #1146
+* Enhancement - Add patch order data filter #1147
+* Enhancement - Add filter for disabling fees on wc order admin pages #1153
+* Enhancement - Use wp_loaded for fraudnet loading to avoid warnings #1172
+* Enhancement - reCaptcha for WooCommerce support #1093
+* Enhancement - Make it possible to hide missing funding resource Trustly #1155
+* Enhancement - Add white color option #1167
+* Enhancement - Checkout validation for other fields #861
+* Enhancement - Mention PUI only for German shops and add line breaks #1169
+* Enhancement - Add filter to fallback tracking_data['carrier'] #1188
+* Enhancement - Error notices in checkout do not update / or are shown twice #1168
+* Enhancement - capture authorized payment by changing order status (or programmatically) #587
+
+= 2.0.2 - 2023-01-31 =
+* Fix - Do not call PayPal get order by ID if it does not exist #1029
+* Fix - Type check error conflict with German Market #1056
+* Fix - Backend Storage for the PayPalRequestIdRepository does not scale #983
+* Fix - Ensure WC()->payment_gateways is not null #1128
+* Enhancement - Remove plugin data after uninstalling #1075
+* Enhancement - Add FraudNet to all payments #1040
+* Enhancement - Update "Standard Payments" tab settings #1065
+* Enhancement - Update PHP 7.2 requirement in all relevant files #1084
+* Enhancement - When PUI is enabled FraudNet should be also enabled #1129
+* Enhancement - Add PayPal-Request-Id if payment source exist #1132
+
+= 2.0.1 - 2022-12-13 =
+* Fix - Error while syncing tracking data to PayPal -> Sync GZD Tracking #1020
+* Fix - Fix product price retrieval for variable product buttons #1000
+* Fix - All tabs hidden on OXXO tab visit #1048
+* Fix - Woocommerce Germanized Invoice bug #1017
+* Fix - Fix shipping address validation #1047
+* Fix - Trigger WC JS validation on button click to highlight empty fields #1004
+* Fix - Fix PHP 8.1 deprecated error #1009
+* Fix - Wrong asset path Germanized compat #1051
+* Fix - Fix DCC error messages handling #1035
+* Fix - Execute WC validation only for smart buttons in checkout #1074
+* Enhancement - Param types removed in closure to avoid third-party issues #1046
+
+= 2.0.0 - 2022-11-21 =
+* Add - Option to separate JSSDK APM payment buttons into individual WooCommerce gateways #671
+* Add - OXXO APM (Alternative Payment Method) #684
+* Add - Pay Later tab #961
+* Add - Button preview in settings #929
+* Fix - Prevent Enter key submit for our non-standard button gateways #981
+* Fix - Pay Upon Invoice - Stock correction on failed orders #964
+* Fix - Check that WC session exists before using it #846
+* Fix - Compatibility with One Page Checkout Extension #356
+* Fix - Tracking status filter sending wrong parameter #970
+* Enhancement - Compatibility with WC High-Performance Order Storage #933
+* Enhancement - PHP 8.1 warning: Constant FILTER_SANITIZE_STRING is deprecated #867
+* Enhancement - Execute server-side WC validation when clicking button #942
+* Enhancement - Update order with order note if payment failed after billing agreement canceled at PayPal #886
+* Enhancement - Missing PUI refund functionality from WC order #937
+* Enhancement - Hide Pay upon Invoice tab if not available for merchant #978
+* Enhancement - Handle synced sub without upfront payment like free trial #936
+* Enhancement - Isolate container and modularity deps #972
+  **NOTE**: if you were extending/modifying the plugin using the modularity system,
+  you will need to add the `WooCommerce\PayPalCommerce\Vendor\`  prefix for the container/modularity namespaces in your code,
+  that is `Psr\Container\ContainerInterface` becomes `WooCommerce\PayPalCommerce\Vendor\Psr\Container\ContainerInterface`,
+  and `Dhii\Modular\Module\ModuleInterface` becomes `WooCommerce\PayPalCommerce\Vendor\Dhii\Modular\Module\ModuleInterface`.
+* Enhancement - PUI gateway displayed on pay for order page when mandatory billing fields are left empty or country is unsupported #966
+* Enhancement - When Brand Name field is left empty, PUI purchase fails #916
+* Enhancement - Improve styling when using separate buttons #996
+
+= 1.9.5 - 2022-11-01 =
+* Fix - Invalid tracking number in logs when adding tracking #903
+* Fix - Tracking on Connection tab always enabled #900
+* Fix - PUI payment instructions printed in the refund email #873
+* Fix - Fix `thankyou_order_received` filter usage #899
+* Enhancement - Add SCA payment indicator for credit card renewals #847
+* Enhancement - Rename plugin settings tabs #893
+* Enhancement - Hide order button via class #921
+* Enhancement - Tracking integration compatibility with Germanized plugin #883
+* Enhancement - Onboarding buttons must be clicked multiple times after using PUI checkbox #851
+* Enhancement - Ratepay payment instructions added to non Pay upon Invoice orders #892
+* Enhancement - During PayPal express checkout PUI js file is loaded #905
+* Enhancement - PayPal Transaction Key meta field not populated for PUI payments #897
+* Enhancement - Onboard with PUI Checkbox automatically set when shop is set to Germany #876
+* Enhancement - Update all plugin strings #946
+
+= 1.9.4 - 2022-10-11 =
+* Add - Create new connection tab #801
+* Add - Functionality to choose subscription failure behavior #728
+* Fix - Virtual-only orders always move order status to completed #868
+* Fix - PayPal order created twice when context is checkout #832
+* Enhancement - Handle unsupported browsers better #843
+* Enhancement - Combine the Webhooks Status page into a new Connection tab (891) #827
+* Enhancement - Hide PayPal Card Processing tab if not available in country or for merchant #870
+* Enhancement - Resubscribe webhooks on plugin upgrades #838
+* Enhancement - PUI-relevant webhook not subscribed to #842
+* Enhancement - Remove WC logo during onboarding #881
+
+= 1.9.3 - 2022-08-31 =
+* Add - Tracking API #792
+* Fix - Improve compatibility with Siteground Optimizer plugin #797
+* Fix - Transaction ID in order not updated when manually capturing authorized payment from WC #766
+* Fix - Failed form validation on Checkout page causing page to be sticky #781
+* Fix - Do not include full path in exception #779
+* Fix - PUI conflict with Germanized plugin and taxes #808
+* Enhancement - Enable ACDC by default only in locations where WooCommerce Payments is not available #799
+* Enhancement - Add links to docs & support in plugin #782
+* Enhancement - Put gateway sub-options into tabs #772
+* Enhancement - Show tabs only after onboarding #789
+* Enhancement - Add header on settings page #790
+* Enhancement - PUI add option for a phone number field next to the Birth Date field #742
+* Enhancement - PUI gateway availability on pay for order page with unsupported currency #744
+
+= 1.9.2 - 2022-08-09 =
+* Fix - Do not allow birth date older than 100 years for PUI. #743
+* Fix - Store the customer id for vaulted payment method in usermeta to not lose vaulted methods after the invoice prefix change. #698
+* Fix - Capture Virtual-Only Orders setting did not auto-capture subscription renewal payments. #626
+* Fix - Voiding authorization at PayPal did not update the status/order notes. #712
+* Fix - PayPal scripts were loading on pages without smart buttons or Pay Later messaging. #750
+* Fix - Do not show links for unavailable gateways settings pages. #753
+* Fix - The smart buttons were not loaded on single product page if a subscription product exists in the cart. #703
+* Fix - DCC was causing other gateways to disappear after checkout validation error. #757
+* Fix - Buttons not loading on single product page with default settings when product is in cart. #777
+* Enhancement - Improve Checkout Field Validation Message. #739
+* Enhancement - Handle PAYER_ACTION_REQUIRED error. #759
+
+= 1.9.1 - 2022-07-25 =
+* Fix - ITEM_TOTAL_MISMATCH error when checking out with multiple products #721
+* Fix - Unable to purchase a product with Credit card button in pay for order page #718
+* Fix - Pay Later messaging only displayed when smart button is active on the same page #283
+* Fix - Pay Later messaging displayed for out of stock variable products or with no variation selected #667
+* Fix - Placeholders and card type detection not working for PayPal Card Processing (260) #685
+* Fix - PUI gateway is displayed with unsupported store currency #711
+* Fix - Wrong PUI locale sent causing error PAYMENT_SOURCE_CANNOT_BE_USED #741
+* Enhancement - Missing PayPal fee in WC order details for PUI purchase #714
+* Enhancement - Skip loading of PUI js file on all pages where PUI gateway is not displayed #723
+* Enhancement - PUI feature capitalization not consistent #724
+
+= 1.9.0 - 2022-07-04 =
+* Add - New Feature - Pay Upon Invoice (Germany only) #608
+* Fix - Order not approved: payment via vaulted PayPal account fails #677
+* Fix - Cant' refund : "ERROR Refund failed: No country given for address." #639
+* Fix - Something went wrong error in Virtual products when using vaulted payment #673
+* Fix - PayPal smart buttons are not displayed for product variations when parent product is set to out of stock #669
+* Fix - Pay Later messaging displayed for out of stock variable products or with no variation selected #667
+* Fix - "Capture Virtual-Only Orders" intent sets virtual+downloadable product orders to "Processing" instead of "Completed" #665
+* Fix - Free trial period causing incorrerct disable-funding parameters with DCC disabled #661
+* Fix - Smart button not visible on single product page when product price is below 1 and decimal is "," #654
+* Fix - Checkout using an email address containing a + symbol results in a "[INVALID_REQUEST]" error #523
+* Fix - Order details are sometimes empty in PayPal dashboard #689
+* Fix - Incorrect TAX details on PayPal order overview #541
+* Fix - Fatal error: Uncaught Error: Call to a member function get_name() on bool #622
+* Fix - DCC causes checkout continuation state after checkout validation error #695
+* Enhancement - Improve checkout validation & order creation #513
+
+= 1.8.1 - 2022-05-31 =
+* Fix - Manual orders return an error for guest users when paying with PayPal Card Processing #530
+* Fix - "No PayPal order found in the current WooCommerce session" error for guests on Pay for Order page #605
+* Fix - Error on order discount by third-party plugins #548
+* Fix - Empty payer data may cause CITY_REQUIRED error for certain checkout countries #632
+* Fix - Mini Cart smart buttons visible after adding subscription product to cart from "shop" page while Vaulting is disabled #624
+* Fix - Smart buttons not loading when free product is in cart but shipping costs are available #606
+* Fix - Smart button & Pay Later messaging disappear on the cart page after changing shipping method #288
+* Fix - Disabling PayPal Checkout on the checkout page also removes the button from the Cart and Product Pages #577
+* Fix - Partial refunds via PayPal are created twice/double in WooCommerce order #522
+* Fix - Emoji in product description causing INVALID_STRING_LENGTH error #491
+* Enhancement - Vaulting & Pay Later UI/UX #174
+* Enhancement - Redirect after updating settings for DCC sends you to PPCP settings screen #392
+* Enhancement - Add Fraud Processor Response as an order note #616
+* Enhancement - Add the Paypal Fee to the Meta Custom Field for export purposes #591
+
+= 1.8.0 - 2022-05-03 =
+* Add - Allow free trial subscriptions #580
+* Fix - The Card Processing does not appear as an available payment method when manually creating an order #562
+* Fix - Express buttons & Pay Later visible on variable Subscription products /w disabled vaulting #281
+* Fix - Pay for order (guest) failing when no email address available #535
+* Fix - Emoji in product description causing INVALID_STRING_LENGTH error #491
+* Enhancement - Change cart total amount that is sent to PayPal gateway #486
+* Enhancement - Include dark Visa and Mastercard gateway icon list for PayPal Card Processing #566
+* Enhancement - Onboarding errors improvements #558
+* Enhancement - "Place order" button visible during gateway load time when DCC gateway is selected as the default #560
+
+= 1.7.1 - 2022-04-06 =
+* Fix - Hide smart buttons for free products and zero-sum carts #499
+* Fix - Unprocessable Entity when paying with AMEX card #516
+* Fix - Multisite path doubled in ajax URLs #528
+* Fix - "Place order" button looking unstyled in the Twenty Twenty-Two theme #478
+* Fix - PayPal options available on minicart when adding subscription to the cart from shop page without vaulting enabled #518
+* Fix - Buttons not visible on products page #551
+* Fix - Buttons not visible in mini-cart #553
+* Fix - PayPal button missing on pay for order page #555
+* Enhancement - PayPal buttons loading time #533
+* Enhancement - Improve payment token checking for subscriptions #525
+* Enhancement - Add Spain and Italy to messaging #497
+
+= 1.7.0 - 2022-02-28 =
+* Fix - DCC orders randomly failing #503
+* Fix - Multi-currency broke #481
+* Fix - Address information from PayPal shortcut flow not loaded #451
+* Fix - WooCommerce as mu-plugin is not detected as active #461
+* Fix - Check if PayPal Payments is an available gateway before displaying it on Product/Cart pages #447
+* Enhancement - Improve onboarding flow, allow no card processing #443 #508 #510
+* Enhancement - Add Germany to supported ACDC countries #459
+* Enhancement - Add filters to allow ACDC for countries #437
+* Enhancement - Update 3D Secure #464
+* Enhancement - Extend event, error logging & order notes #456
+* Enhancement - Display API response errors in checkout page with user-friendly error message #457
+* Enhancement - Pass address details to credit card fields #479
+* Enhancement - Improve onboarding notice #465
+* Enhancement - Add transaction ID to WC order and order note when refund is received #473
+* Enhancement - Asset caching may cause bugs on upgrades #501
+* Enhancement - Allow partial capture #483
+* Enhancement - PayPal Payments doesn't set transaction fee metadata #467
+* Enhancement - Show PayPal fee information in order #489
+
+= 1.6.5 - 2022-01-31 =
+* Fix - Allow guest users to purchase subscription products from checkout page #422
+* Fix - Transaction ID missing for renewal order #424
+* Fix - Save your credit card checkbox should be removed in pay for order for subscriptions #420
+* Fix - Null currency error when the Aelia currency switcher plugin is active #426
+* Fix - Hide Reference Transactions check from logs #428
+* Fix - Doubled plugin module URL path causing failure #438
+* Fix - is_ajax deprecated #441
+* Fix - Place order button from PayPal Card Processing does not get translated #290
+* Fix - AMEX missing from supported cards for DCC Australia #432
+* Fix - "Save your Credit Card" text not clickable to change checkbox state #430
+* Fix - Improve DCC error notice when not available #435
+* Enhancement - Add View Logs link #416
+
+= 1.6.4 - 2021-12-27 =
+* Fix - Non admin user cannot save changes to the plugin settings #278
+* Fix - Empty space in invoice prefix causes smart buttons to not load #390
+* Fix - woocommerce_payment_complete action not triggered for payments completed via webhook #399
+* Fix - Paying with Venmo - Change funding source on checkout page and receipt to Venmo  #394
+* Fix - Internal server error on checkout when selected saved card but then switched to paypal #403
+* Enhancement - Allow formatted text for the Description field #407
+* Enhancement - Remove filter to prevent On-Hold emails #411
+
+= 1.6.3 - 2021-12-14 =
+* Fix - Payments fail when using custom order numbers #354
+* Fix - Do not display saved payments on PayPal buttons if vault option is disabled #358
+* Fix - Double "Place Order" button #362
+* Fix - Coupon causes TAX_TOTAL_MISMATCH #372
+* Fix - Funding sources Mercado Pago and BLIK can't be disabled #383
+* Fix - Customer details not available in order and name gets replaced by xxx@dcc2.paypal.com #378
+* Fix - 3D Secure failing for certain credit card types with PayPal Card Processing #379
+* Fix - Error messages are not cleared even when checkout is re-attempted (DCC) #366
+* Add - New additions for system report status #377
+
+= 1.6.2 - 2021-11-22 =
+* Fix - Order of WooCommerce checkout actions causing incompatibility with AvaTax address validation #335
+* Fix - Can't checkout to certain countries with optional postcode #330
+* Fix - Prevent subscription from being purchased when saving payment fails #308
+* Fix - Guest users must checkout twice for subscriptions, no smart buttons loaded #342
+* Fix - Failed PayPal API request causing strange error #347
+* Fix - PayPal payments page empty after switching packages #350
+* Fix - Could Not Validate Nonce Error #239
+* Fix - Refund via PayPal dashboard does not set the WooCommerce order to "Refunded" #241
+* Fix - Uncaught TypeError: round() #344
+* Fix - Broken multi-level (nested) associative array values after getting submitted from checkout page #307
+* Fix - Transaction id missing in some cases #328
+* Fix - Payment not possible in pay for order form because of terms checkbox missing #294
+* Fix - "Save your Credit Card" shouldn't be optional when paying for a subscription #368
+* Fix - When paying for a subscription and vaulting fails, cart is cleared #367
+* Fix - Fatal error when activating PayPal Checkout plugin #363
+
+= 1.6.1 - 2021-10-12 =
+* Fix - Handle authorization capture failures #312
+* Fix - Handle denied payment authorization #302
+* Fix - Handle failed authorizations when capturing order #303
+* Fix - Transactions cannot be voided #293
+* Fix - Fatal error: get_3ds_contingency() #310
+
+= 1.6.0 - 2021-09-29 =
+* Add - Webhook status. #246 #273
+* Add - Show CC gateway in admin payments list. #236
+* Add - Add 3d secure contingency settings. #230
+* Add - Improve logging. #252 #275
+* Add - Do not send payee email. #231
+* Add - Allow customers to see and delete their saved payments in My Account. #274
+* Fix - PayPal Payments generates multiple orders. #244
+* Fix - Saved credit card does not auto fill. #242
+* Fix - Incorrect webhooks registration. #254
+* Fix - Disable funding credit cards affecting hosted fields, unset for GB. #249
+* Fix - REFUND_CAPTURE_CURRENCY_MISMATCH on multicurrency sites. #225
+* Fix - Can't checkout to certain countries with optional postcode. #224
+
+= 1.5.1 - 2021-08-19 =
+* Fix - Set 3DS contingencies to "SCA_WHEN_REQUIRED". #178
+* Fix - Plugin conflict blocking line item details. #221
+* Fix - WooCommerce orders left in "Pending Payment" after a decline. #222
+* Fix - Do not send decimals when currency does not support them. #202
+* Fix - Gateway can be activated without a connected PayPal account. #205
+
+= 1.5.0 - 2021-08-09 =
+* Add - Filter to modify plugin modules list. #203
+* Add - Filters to move PayPal buttons and Pay Later messages. #203
+* Fix - Remove redirection when enabling payment gateway with setup already done. #206
+* Add - PayPal Express Checkout compatibility layer. #207
+* Fix - Use correct API to obtain credit card icons. #210
+* Fix - Hide mini cart height field when mini cart is disabled. #213
+* Fix - Address possible error on frontend pages due to an empty gateway description. #214
+
+= 1.4.0 - 2021-07-27 =
+* Add - Venmo update #169
+* Add - Pay Later Button –Global Expansion #182
+* Add - Add Canada to advanced credit and debit card #180
+* Add - Add button height setting for mini cart #181
+* Add - Add BN Code to Pay Later Messaging #183
+* Add - Add 30 seconds timeout by default to all API requests #184
+* Fix - ACDC checkout error: "Card Details not valid"; but payment completes #193
+* Fix - Incorrect API credentials cause fatal error #187
+* Fix - PayPal payment fails if a new user account is created during the checkout process #177
+* Fix - Disabled PayPal button appears when another button is loaded on the same page #192
+* Fix - [UNPROCESSABLE_ENTITY] error during checkout #172
+* Fix - Do not send customer email when order status is on hold #173
+* Fix - Remove merchant-id query parameter in JSSDK #179
+* Fix - Error on Plugin activation with Zettle POS Integration for WooCommerce #195
+
+= 1.3.2 - 2021-06-08 =
+* Fix - Improve Subscription plugin support. #161
+* Fix - Disable vault setting if vaulting feature is not available. #150
+* Fix - Cast item get_quantity into int. #168
+* Fix - Fix Credit Card form fields placeholder and label. #146
+* Fix - Filter PayPal-supported language codes. #154
+* Fix - Wrong order status for orders with contain only products which are both virtual and downloadable. #145
+* Fix - Use order_number instead of internal id when creating invoice Id. #163
+* Fix - Fix pay later messaging options. #141
+* Fix - UI/UX for vaulting settings. #166
+
+= 1.3.1 - 2021-04-30 =
+* Fix - Fix Credit Card fields for non logged-in users. #152
+
+= 1.3.0 - 2021-04-28 =
+* Add - Client-side vaulting and allow WooCommerce Subscriptions product renewals through payment tokens. #134
+* Add - Send transaction ids to woocommerce. #125
+* Fix - Validate checkout form before sending request to PayPal #137
+* Fix - Duplicate Invoice Id error. #143
+* Fix - Unblock UI if Credit Card payment failed. #122
+* Fix - Detected container element removed from DOM. #123
+* Fix - Remove disabling credit for UK. #127
+* Fix - Show WC message on account creating error. #136
+
+= 1.2.1 - 2021-03-08 =
+* Fix - Address compatibility issue with Jetpack.
+
+= 1.2.0 - 2021-03-08 =
+* Add - Rework onboarding code and add REST controller for integration with the OBW. #121
+* Fix - Remove spinner on click, on cancel and on error. #124
+
+= 1.1.0 - 2021-02-01 =
+* Add - Buy Now Pay Later for UK. #104
+* Add - DE now has 12 month installments. #106
+* Fix - Check phone for empty string. #102
+
+= 1.0.4 - 2021-01-18 =
+* Fix - Check if WooCommerce is active before initialize. #99
+* Fix - Payment buttons only visible on order-pay site when Mini Cart is enabled; payment fails. #96
+* Fix - High volume of failed calls to /v1/notifications/webhooks #93
+* Fix - GB country has ACDC blocked. #91
+
+= 1.0.3 - 2020-11-30 =
+* Fix - Order with Payment received when Hosted Fields transaction is declined. #88
+
+= 1.0.2 - 2020-11-09 =
+* Fix - Purchases over 1.000 USD fail. #84
+
+= 1.0.1 - 2020-11-05 =
+* Fix - PayPal Smart buttons don't load when using a production/live account and `WP_Debug` is turned on/true. #66
+* Fix - [Card Processing] SCA/Visa Verification form loads underneath the Checkout blockUI element. #63
+* Fix - Attempting to checkout without country selected results in unexpected error message. #67
+* Fix - Remove ability to change shipping address on PayPal from checkout page. #72
+* Fix - Amount value should be a string when send to the api. #76
+* Fix - "The value of a field does not conform to the expected format" error when using certain e-mail addresses. #56
+* Fix - HTML tags in Product description. #79
+
+= 1.0.0 - 2020-10-15 =
+* Initial release.


### PR DESCRIPTION
Add changelog.txt to ensure correct version number is displayed on WooCommerce.com

The version number was previously replaced by a date (2024.11.12) on the product page:
https://woocommerce.com/products/klarna-payments/

This update follows the changelog format recommended in the documentation:
https://developer.woocommerce.com/docs/extensions/core-concepts/changelog-txt/
