### PR TITLE
Fixes the recurring token missing for redirect flow

### DIFF
--- a/classes/class-kp-ajax.php
+++ b/classes/class-kp-ajax.php
@@ -73,19 +73,18 @@ if ( ! class_exists( 'KP_AJAX' ) ) {
 
 			$recurring_token = false;
 			if ( KP_Subscription::order_has_subscription( $order ) ) {
-				$response = KP_WC()->api->create_customer_token( kp_get_klarna_country( $order ), $auth_token, $order_id );
-				if ( is_wp_error( $response ) ) {
+				$customer_token = KP_Subscription::create_customer_token( $order, $auth_token );
+				if ( is_wp_error( $customer_token ) ) {
 					wp_send_json_error( 'customer_token_failed' );
 				}
 
-				$recurring_token = $response['token_id'];
+				KP_Subscription::save_recurring_token( $order_id, $recurring_token );
 
 				/* translators: Recurring token. */
 				$order->add_order_note( sprintf( __( 'Recurring token created: %s', 'klarna-payments-for-woocommerce' ), $recurring_token ) );
 
 				if ( 0.0 === floatval( $order->get_total() ) ) {
 					$order->payment_complete();
-					KP_Subscription::save_recurring_token( $order_id, $recurring_token );
 					$order->add_order_note( __( 'The order contains a free or trial subscription, and no Klarna order is associated with this purchase. A Klarna order will only be registered once the subscriber is charged.', 'klarna-payments-for-woocommerce' ) );
 
 					kp_unset_session_values();

--- a/classes/class-kp-ajax.php
+++ b/classes/class-kp-ajax.php
@@ -73,8 +73,8 @@ if ( ! class_exists( 'KP_AJAX' ) ) {
 
 			$recurring_token = false;
 			if ( KP_Subscription::order_has_subscription( $order ) ) {
-				$customer_token = KP_Subscription::create_customer_token( $order, $auth_token );
-				if ( is_wp_error( $customer_token ) ) {
+				$recurring_token = KP_Subscription::create_customer_token( $order, $auth_token );
+				if ( is_wp_error( $recurring_token ) ) {
 					wp_send_json_error( 'customer_token_failed' );
 				}
 

--- a/classes/class-kp-api.php
+++ b/classes/class-kp-api.php
@@ -99,6 +99,7 @@ class KP_Api {
 		);
 		$response = $request->request();
 
+		do_action( 'kp_after_place_order', $response, $order_id, $auth_token );
 		return self::check_for_api_error( $response );
 	}
 

--- a/classes/class-kp-callbacks.php
+++ b/classes/class-kp-callbacks.php
@@ -110,7 +110,6 @@ class KP_Callbacks {
 				$order->add_order_note( __( 'Failed to complete the order during the authentication callback.', 'klarna-payments-for-woocommerce' ) );
 				break;
 		}
-
 	}
 
 	/**
@@ -124,7 +123,7 @@ class KP_Callbacks {
 		$order_key  = filter_input( INPUT_GET, 'key', FILTER_SANITIZE_SPECIAL_CHARS );
 
 		// Return if anything is null.
-		if ( null === $session_id || null === $auth_token || null === $order_key ) {
+		if ( ! isset( $session_id, $auth_token, $order_key ) ) {
 			return;
 		}
 

--- a/classes/class-kp-subscriptions.php
+++ b/classes/class-kp-subscriptions.php
@@ -299,12 +299,12 @@ class KP_Subscription {
 	 *
 	 * @param WC_Order $order The WooCommerce order.
 	 * @param string   $auth_token The Klarna auth token for the session.
-	 * @return string|WP_Error The token ID or a WP_Error if the request failed.
+	 * @return string|WP_Error The token ID or the WP_Error associated with the failed request.
 	 */
 	public static function create_customer_token( $order, $auth_token ) {
 		$country  = kp_get_klarna_country( $order );
 		$response = KP_WC()->api->create_customer_token( $country, $auth_token, $order->get_id() );
-		return is_wp_error( $response ) ? false : $response['token_id'];
+		return is_wp_error( $response ) ? $response : $response['token_id'];
 	}
 
 	/**

--- a/classes/class-kp-subscriptions.php
+++ b/classes/class-kp-subscriptions.php
@@ -44,6 +44,40 @@ class KP_Subscription {
 		add_action( 'woocommerce_admin_order_data_after_billing_address', array( $this, 'show_recurring_token' ) );
 		// Ensure wp_safe_redirect do not redirect back to default dashboard or home page.
 		add_filter( 'allowed_redirect_hosts', array( $this, 'extend_allowed_domains_list' ) );
+
+		// Creates and saves the customer token after the order is successfully placed.
+		add_action( 'kp_after_place_order', array( $this, 'add_recurring_token_to_order' ), 10, 3 );
+	}
+
+	/**
+	 * Add the recurring token to the order after successfully placing the order provided it has a subscription.
+	 *
+	 * @param array|WP_Error $response The response from the API.
+	 * @param int            $order_id The order ID.
+	 * @param string         $auth_token The authorization token.
+	 * @return void
+	 * */
+	public function add_recurring_token_to_order( $response, $order_id, $auth_token ) {
+		if ( is_wp_error( $response ) ) {
+			return;
+		}
+
+		$order = wc_get_order( $order_id );
+		if ( ! self::order_has_subscription( $order ) ) {
+			return;
+		}
+
+		$token_from_order = $order->get_meta( self::RECURRING_TOKEN, true );
+		if ( ! empty( $token_from_order ) ) {
+			return;
+		}
+
+		$customer_token = self::create_customer_token( $order, $auth_token );
+		if ( ! is_wp_error( $customer_token ) ) {
+			self::save_recurring_token( $order_id, $customer_token );
+			/* translators: Recurring token. */
+			$order->add_order_note( sprintf( __( 'Recurring token created: %s', 'klarna-payments-for-woocommerce' ), $customer_token ) );
+		}
 	}
 
 	/**
@@ -258,6 +292,19 @@ class KP_Subscription {
 
 		$request['body'] = wp_json_encode( $body );
 		return $request;
+	}
+
+	/**
+	 * Create a customer token from a given authorization token.
+	 *
+	 * @param WC_Order $order The WooCommerce order.
+	 * @param string   $auth_token The Klarna auth token for the session.
+	 * @return string|WP_Error The token ID or a WP_Error if the request failed.
+	 */
+	public static function create_customer_token( $order, $auth_token ) {
+		$country  = kp_get_klarna_country( $order );
+		$response = KP_WC()->api->create_customer_token( $country, $auth_token, $order->get_id() );
+		return is_wp_error( $response ) ? false : $response['token_id'];
 	}
 
 	/**


### PR DESCRIPTION
The redirect flow doesn't trigger `KP_AJAX::kp _wc_place_order` function, which is responsible for requesting and saving the recurring token.

- added `kp_after_place_order` action hook as the existing `wc_klarna_payments_place_order_args` is used for filtering the place order request only.
- uses the `kp_after_place_order` action hook to request and save a recurring token. This ensure all checkout flows are covered.
- moved `create_customer_token` to subscription class to keep logic consistent.

https://app.clickup.com/t/8698ny0eb