### PR TITLE
Refactor to use get_pay_button_label method

### DIFF
--- a/blocks/src/payment/KlarnaPayments.php
+++ b/blocks/src/payment/KlarnaPayments.php
@@ -8,6 +8,7 @@
 namespace KlarnaPayments\Blocks\Payments;
 
 use Automattic\WooCommerce\Blocks\Payments\Integrations\AbstractPaymentMethodType;
+use WC_Klarna_Payments;
 
 /**
  * Class for KP Payment Blocks.
@@ -83,7 +84,7 @@ class KlarnaPayments extends AbstractPaymentMethodType {
 			'title'            => 'Klarna',
 			'description'      => $this->get_setting( 'description' ),
 			'iconurl'          => apply_filters( 'kp_blocks_logo', WC_KLARNA_PAYMENTS_PLUGIN_URL . '/assets/img/klarna-logo.svg' ),
-			'orderbuttonlabel' => apply_filters( 'kp_blocks_order_button_label', __( 'Pay with Klarna', 'klarna-payments-for-woocommerce' ) ),
+			'orderbuttonlabel' => WC_Klarna_Payments::get_pay_button_label(),
 			'features'         => $features,
 		);
 	}

--- a/classes/class-kp-assets.php
+++ b/classes/class-kp-assets.php
@@ -152,7 +152,7 @@ class KP_Assets {
 			) : null,
 			// i18n.
 			'i18n'                   => array(
-				'order_button_label' => apply_filters( 'kp_blocks_order_button_label', __( 'Pay with Klarna', 'klarna-payments-for-woocommerce' ) ),
+				'order_button_label' => WC_Klarna_Payments::get_pay_button_label(),
 				'terms_not_checked'  => __( 'Please read and accept the terms and conditions to proceed with your order.', 'klarna-payments-for-woocommerce' ),
 			),
 		);

--- a/klarna-payments-for-woocommerce.php
+++ b/klarna-payments-for-woocommerce.php
@@ -541,6 +541,20 @@ if ( ! class_exists( 'WC_Klarna_Payments' ) ) {
 				KlarnaPayments::register();
 			}
 		}
+
+		/**
+		 * Get the pay button label depending on cart total.
+		 *
+		 * @return string
+		 */
+		public static function get_pay_button_label() {
+
+			if ( isset( WC()->cart ) && 0 == WC()->cart->total ) {
+				return apply_filters( 'kp_blocks_order_button_label_free', __( 'Pay with Klarna (free)', 'klarna-payments-for-woocommerce' ) );
+			}
+
+			return apply_filters( 'kp_blocks_order_button_label', __( 'Pay with Klarna', 'klarna-payments-for-woocommerce' ) );
+		}
 	}
 	WC_Klarna_Payments::get_instance();
 


### PR DESCRIPTION
Refactor to use `get_pay_button_label` method to filter two pay button labels, depending on if the order is free or not.

The default free label is just an example, I assume it's in need of a change :)