### PR TITLE
Add support export order button

### DIFF
--- a/.changelogs/2026-04-03-include-order-export-feature
+++ b/.changelogs/2026-04-03-include-order-export-feature
@@ -1,0 +1,4 @@
+Type: Feature
+Needs Documentation: yes
+
+[Support] Added an "Export order for support" button to the order edit page, allowing order information to be exported.

--- a/.changelogs/2026-04-03-include-order-export-feature
+++ b/.changelogs/2026-04-03-include-order-export-feature
@@ -1,4 +1,4 @@
 Type: Feature
 Needs Documentation: yes
 
-[Support] Added an "Export order for support" button to the order edit page, allowing order information to be exported.
+Added an "Export order for support" button to the order edit page, allowing order information to be exported.

--- a/composer-dependencies.json
+++ b/composer-dependencies.json
@@ -3,7 +3,7 @@
     "php": ">=7.4",
     "krokedil/wp-api": "^1.0",
     "krokedil/woocommerce": "^1.8.0",
-    "krokedil/support": "^1.0.2",
+    "krokedil/support": "dev-develop-export-order",
     "krokedil/klarna-express-checkout": "2.1.1",
     "krokedil/klarna-onsite-messaging": "2.1.0",
     "krokedil/settings-page": "1.3.2",

--- a/composer-dependencies.lock
+++ b/composer-dependencies.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ae263ec5a5f1e4f4b71006cc351ba1a0",
+    "content-hash": "2e742a87367940ca8217c3182e44401b",
     "packages": [
         {
             "name": "firebase/php-jwt",
@@ -294,16 +294,16 @@
         },
         {
             "name": "krokedil/support",
-            "version": "1.0.2",
+            "version": "dev-develop-export-order",
             "source": {
                 "type": "git",
                 "url": "https://github.com/krokedil/support.git",
-                "reference": "99059b1b27cc4ed7667c1d04968aec45413fe533"
+                "reference": "57a7baeb6b156050e0c8202b0deaf8006701c1f6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/krokedil/support/zipball/99059b1b27cc4ed7667c1d04968aec45413fe533",
-                "reference": "99059b1b27cc4ed7667c1d04968aec45413fe533",
+                "url": "https://api.github.com/repos/krokedil/support/zipball/57a7baeb6b156050e0c8202b0deaf8006701c1f6",
+                "reference": "57a7baeb6b156050e0c8202b0deaf8006701c1f6",
                 "shasum": ""
             },
             "require": {
@@ -343,10 +343,10 @@
             ],
             "description": "The support library allows you to extend your plugin with logging that can be optionally toggled through your plugin settings, generate an entry in the system report from your plugin settings, and report issues to the system report.",
             "support": {
-                "source": "https://github.com/krokedil/support/tree/1.0.2",
+                "source": "https://github.com/krokedil/support/tree/develop-export-order",
                 "issues": "https://github.com/krokedil/support/issues"
             },
-            "time": "2025-10-08T12:47:46+00:00"
+            "time": "2026-01-16T16:05:43+00:00"
         },
         {
             "name": "krokedil/woocommerce",
@@ -440,7 +440,9 @@
     "packages-dev": [],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": [],
+    "stability-flags": {
+        "krokedil/support": 20
+    },
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {

--- a/composer-dependencies.lock
+++ b/composer-dependencies.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "04c3d0be921247ee2ba54c88872742a8",
+    "content-hash": "9fce2163b37af6bd4f94432f9f090493",
     "packages": [
         {
             "name": "firebase/php-jwt",
@@ -294,16 +294,16 @@
         },
         {
             "name": "krokedil/support",
-            "version": "1.0.3",
+            "version": "dev-develop-export-order",
             "source": {
                 "type": "git",
                 "url": "https://github.com/krokedil/support.git",
-                "reference": "e4ee49d1c862e45fb284247c84d7c1f5583cb6ba"
+                "reference": "a8e0103fea9646533609cc0f1abf84acfc1ffe60"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/krokedil/support/zipball/e4ee49d1c862e45fb284247c84d7c1f5583cb6ba",
-                "reference": "e4ee49d1c862e45fb284247c84d7c1f5583cb6ba",
+                "url": "https://api.github.com/repos/krokedil/support/zipball/a8e0103fea9646533609cc0f1abf84acfc1ffe60",
+                "reference": "a8e0103fea9646533609cc0f1abf84acfc1ffe60",
                 "shasum": ""
             },
             "require": {
@@ -319,7 +319,10 @@
             "autoload": {
                 "psr-4": {
                     "Krokedil\\Support\\": "src/"
-                }
+                },
+                "files": [
+                    "src/bootstrap.php"
+                ]
             },
             "scripts": {
                 "phpcs": [
@@ -343,10 +346,10 @@
             ],
             "description": "The support library allows you to extend your plugin with logging that can be optionally toggled through your plugin settings, generate an entry in the system report from your plugin settings, and report issues to the system report.",
             "support": {
-                "source": "https://github.com/krokedil/support/tree/1.0.3",
+                "source": "https://github.com/krokedil/support/tree/develop-export-order",
                 "issues": "https://github.com/krokedil/support/issues"
             },
-            "time": "2026-03-30T09:30:26+00:00"
+            "time": "2026-04-03T09:27:08+00:00"
         },
         {
             "name": "krokedil/woocommerce",
@@ -440,7 +443,9 @@
     "packages-dev": [],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": [],
+    "stability-flags": {
+        "krokedil/support": 20
+    },
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {

--- a/composer-dependencies.lock
+++ b/composer-dependencies.lock
@@ -298,12 +298,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/krokedil/support.git",
-                "reference": "a8e0103fea9646533609cc0f1abf84acfc1ffe60"
+                "reference": "c687ed59b476d15d90efa2c9b986b5c154824728"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/krokedil/support/zipball/a8e0103fea9646533609cc0f1abf84acfc1ffe60",
-                "reference": "a8e0103fea9646533609cc0f1abf84acfc1ffe60",
+                "url": "https://api.github.com/repos/krokedil/support/zipball/c687ed59b476d15d90efa2c9b986b5c154824728",
+                "reference": "c687ed59b476d15d90efa2c9b986b5c154824728",
                 "shasum": ""
             },
             "require": {
@@ -319,10 +319,7 @@
             "autoload": {
                 "psr-4": {
                     "Krokedil\\Support\\": "src/"
-                },
-                "files": [
-                    "src/bootstrap.php"
-                ]
+                }
             },
             "scripts": {
                 "phpcs": [
@@ -349,7 +346,7 @@
                 "source": "https://github.com/krokedil/support/tree/develop-export-order",
                 "issues": "https://github.com/krokedil/support/issues"
             },
-            "time": "2026-04-03T09:27:08+00:00"
+            "time": "2026-04-08T08:35:24+00:00"
         },
         {
             "name": "krokedil/woocommerce",

--- a/src/OrderManagement.php
+++ b/src/OrderManagement.php
@@ -133,6 +133,16 @@ class OrderManagement {
 			array( 'id' => 'kom_debug_log' ),
 
 		);
+		$this->logger = new Logger( 'klarna_order_management', wc_string_to_bool( $settings['logging'] ?? false ) );
+		$report_about = array(
+			array( 'id' => 'kom_auto_capture' ),
+			array( 'id' => 'kom_auto_cancel' ),
+			array( 'id' => 'kom_auto_update' ),
+			array( 'id' => 'kom_auto_order_sync' ),
+			array( 'id' => 'kom_force_full_capture' ),
+			array( 'id' => 'kom_debug_log' ),
+
+		);
 		$this->system_report = new SystemReport( 'klarna_payments', 'Klarna Order Management for WooCommerce', $report_about );
 
 		// Cancel order.

--- a/src/OrderManagement.php
+++ b/src/OrderManagement.php
@@ -124,8 +124,6 @@ class OrderManagement {
 		// Initialize the logger.
 		add_action( 'init', array( $this, 'initialize_logger' ) );
 
-		$this->logger = new Logger( 'klarna_order_management', wc_string_to_bool( $settings['logging'] ?? false ) );
-
 		$report_about = array(
 			array( 'id' => 'kom_auto_capture' ),
 			array( 'id' => 'kom_auto_cancel' ),

--- a/src/OrderManagement.php
+++ b/src/OrderManagement.php
@@ -124,16 +124,8 @@ class OrderManagement {
 		// Initialize the logger.
 		add_action( 'init', array( $this, 'initialize_logger' ) );
 
-		$report_about = array(
-			array( 'id' => 'kom_auto_capture' ),
-			array( 'id' => 'kom_auto_cancel' ),
-			array( 'id' => 'kom_auto_update' ),
-			array( 'id' => 'kom_auto_order_sync' ),
-			array( 'id' => 'kom_force_full_capture' ),
-			array( 'id' => 'kom_debug_log' ),
-
-		);
 		$this->logger = new Logger( 'klarna_order_management', wc_string_to_bool( $settings['logging'] ?? false ) );
+
 		$report_about = array(
 			array( 'id' => 'kom_auto_capture' ),
 			array( 'id' => 'kom_auto_cancel' ),

--- a/src/OrderManagement/MetaBox.php
+++ b/src/OrderManagement/MetaBox.php
@@ -2,6 +2,7 @@
 namespace Krokedil\Klarna\OrderManagement;
 
 use KrokedilKlarnaPaymentsDeps\Krokedil\WooCommerce\OrderMetabox;
+use KrokedilKlarnaPaymentsDeps\Krokedil\Support\OrderSupport;
 use Krokedil\Klarna\OrderManagement;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -179,6 +180,7 @@ class MetaBox extends OrderMetabox {
 			);
 
 		}
+		( new OrderSupport() )->add_export_order_button( $order, true );
 		self::output_actions_dropdown( $order_id, $klarna_order );
 		self::output_collapsable_section( 'kom-advanced', __( 'Advanced', 'klarna-payments-for-woocommerce' ), self::get_advanced_section_content( $order ) );
 	}

--- a/src/OrderManagement/MetaBox.php
+++ b/src/OrderManagement/MetaBox.php
@@ -23,12 +23,20 @@ class MetaBox extends OrderMetabox {
 	protected $order_management;
 
 	/**
+	 * OrderSupport instance.
+	 *
+	 * @var OrderSupport
+	 */
+	protected $order_support;
+
+	/**
 	 * Class constructor.
 	 *
 	 * @param OrderManagement $order_management Klarna Order Management instance.
 	 */
 	public function __construct( $order_management ) {
 		$this->order_management = $order_management;
+		$this->order_support    = new OrderSupport();
 		parent::__construct( 'klarna-om', 'Klarna Order Management', 'klarna_payments' );
 
 		add_action( 'add_meta_boxes', array( $this, 'kom_meta_box' ) );
@@ -180,7 +188,7 @@ class MetaBox extends OrderMetabox {
 			);
 
 		}
-		( new OrderSupport() )->add_export_order_button( $order, true );
+		$this->order_support->add_export_order_button( $order, true );
 
 		$transaction_id = $order->get_transaction_id();
 


### PR DESCRIPTION
Adds the "Export order for support" button to the order edit page, allowing order information to be exported.