### PR TITLE
Add order note even if om is inactive on capture

### DIFF
--- a/.changelogs/2026-04-20-order-note-inactive-om
+++ b/.changelogs/2026-04-20-order-note-inactive-om
@@ -1,0 +1,4 @@
+Type: Fix
+Needs Documentation: no
+
+Added an order note when changing the order status to completed, if no capture request is sent because auto-capture or order management is inactive for the order.

--- a/src/OrderManagement.php
+++ b/src/OrderManagement.php
@@ -432,6 +432,8 @@ class OrderManagement {
 
 			// The merchant has disconnected the order from the order manager.
 			if ( $order->get_meta( '_kom_disconnect' ) ) {
+				$order->add_order_note( __( 'Klarna capture request was not sent because order management is disabled for this order.', 'klarna-payments-for-woocommerce' ) );
+				$order->save();
 				return new \WP_Error( 'order_sync_off', 'Order management is disabled' );
 			}
 
@@ -524,6 +526,9 @@ class OrderManagement {
 					return new \WP_Error( 'save_error', 'Could not save WooCommerce order object.' );
 				}
 			}
+		} else {
+			$order->add_order_note( __( 'Klarna capture request was not sent because order management is disabled for capture.', 'klarna-payments-for-woocommerce' ) );
+			$order->save();
 		}
 	}
 


### PR DESCRIPTION
Adds an order note when changing the order status to completed, if no capture request is sent because auto-capture or order management is inactive for the order. The purpose of this is improved troubleshooting for orders where no capture request was sent.

Feel free to suggest different messages for the order notes :)