### PR TITLE
Add order note for payment change

### DIFF
--- a/.changelogs/2026-04-21-recurring-order-note
+++ b/.changelogs/2026-04-21-recurring-order-note
@@ -1,0 +1,4 @@
+Type: Fix
+Needs Documentation: no
+
+Added an order note when a new recurring token is created after changing the payment method for a subscription order.

--- a/classes/class-kp-subscriptions.php
+++ b/classes/class-kp-subscriptions.php
@@ -272,7 +272,11 @@ class KP_Subscription {
 				$response->get_error_message()
 			);
 		} else {
-			self::save_recurring_token( $subscription_id, $response['token_id'] );
+			$recurring_token = $response['token_id'];
+			self::save_recurring_token( $subscription_id, $recurring_token );
+
+			/* translators: Recurring token. */
+			$message = sprintf( __( 'Recurring token created: %s', 'klarna-payments-for-woocommerce' ), $recurring_token );
 		}
 
 		$subscription->add_order_note( $message );


### PR DESCRIPTION
Adds an order note when a new recurring token is created after changing the payment method for a subscription order.