### PR TITLE
Fix Uncaught TypeError

### DIFF
--- a/.changelogs/2026-05-04-fix-typerror-wp-hook
+++ b/.changelogs/2026-05-04-fix-typerror-wp-hook
@@ -1,0 +1,4 @@
+Type: Fix
+Needs Documentation: no
+
+Resolved an issue where a fatal error could occur in the order management metabox in some environments.

--- a/classes/class-kp-logger.php
+++ b/classes/class-kp-logger.php
@@ -169,8 +169,9 @@ class KP_Logger {
 				if ( ! $wp_hook_current ) {
 					return;
 				}
-				$current  = current( $wp_hook_current );
-				$name     = '';
+				$current = current( $wp_hook_current );
+				$name    = '';
+
 				$callback = $current['function'] ?? null;
 				if ( is_array( $callback ) ) {
 					foreach ( $callback as $callback_item ) {

--- a/classes/class-kp-logger.php
+++ b/classes/class-kp-logger.php
@@ -166,15 +166,11 @@ class KP_Logger {
 			if ( $wp_hook instanceof WP_Hook ) {
 				$priority        = $wp_hook->current_priority();
 				$wp_hook_current = $wp_hook->current();
-
 				if ( ! $wp_hook_current ) {
 					return;
 				}
-
-				$current = current( $wp_hook_current );
-
-				$name = '';
-
+				$current  = current( $wp_hook_current );
+				$name     = '';
 				$callback = $current['function'] ?? null;
 				if ( is_array( $callback ) ) {
 					foreach ( $callback as $callback_item ) {

--- a/classes/class-kp-logger.php
+++ b/classes/class-kp-logger.php
@@ -164,9 +164,16 @@ class KP_Logger {
 		if ( 'WP_Hook' === $class_name && in_array( $function_name, array( 'apply_filters', 'do_action' ), true ) ) {
 			$wp_hook = $debug_line['object'] ?? null;
 			if ( $wp_hook instanceof WP_Hook ) {
-				$priority = $wp_hook->current_priority();
-				$current  = current( $wp_hook->current() );
-				$name     = '';
+				$priority        = $wp_hook->current_priority();
+				$wp_hook_current = $wp_hook->current();
+
+				if ( ! $wp_hook_current ) {
+					return;
+				}
+
+				$current = current( $wp_hook_current );
+
+				$name = '';
 
 				$callback = $current['function'] ?? null;
 				if ( is_array( $callback ) ) {


### PR DESCRIPTION
Resolves error `An error of type E_ERROR was caused in line 168 of the file /home/inkfusedtfco/public_html/wp-content/plugins/klarna-payments-for-woocommerce/classes/class-kp-logger.php. Error message: Uncaught TypeError: current(): Argument #1 ($array) must be of type array, false given`.

Please read my comment in the related ClickUp card: https://app.clickup.com/t/869d5cy3u