### PR TITLE
Always register the script module

### DIFF
--- a/.changelogs/2026-05-08-client-id-error-handling
+++ b/.changelogs/2026-05-08-client-id-error-handling
@@ -1,0 +1,4 @@
+Type: Fix
+Needs Documentation: no
+
+Fixed a PHP warning that occurred when an invalid or missing client ID was provided for boost features.

--- a/classes/class-kp-assets.php
+++ b/classes/class-kp-assets.php
@@ -380,16 +380,16 @@ class KP_Assets {
 	public function enqueue_interoperability_token() {
 		$client_id = kp_get_client_id();
 
-		if ( empty( $client_id ) ) {
-			return;
-		}
-
 		wp_register_script_module(
 			'@klarna/interoperability_token',
 			plugins_url( 'assets/js/klarna-interoperability-token.js', WC_KLARNA_PAYMENTS_MAIN_FILE ),
 			array( self::KP_WEBSDK_HANDLE_V2 ),
 			WC_KLARNA_PAYMENTS_VERSION
 		);
+
+		if ( empty( $client_id ) ) {
+			return;
+		}
 
 		$params = array(
 			'client_id' => $client_id,

--- a/composer-dependencies.json
+++ b/composer-dependencies.json
@@ -4,8 +4,8 @@
     "krokedil/wp-api": "^1.0",
     "krokedil/woocommerce": "^1.8.0",
     "krokedil/support": "1.0.3",
-    "krokedil/klarna-express-checkout": "2.1.4",
-    "krokedil/klarna-onsite-messaging": "2.1.1",
+    "krokedil/klarna-express-checkout": "dev-develop-check-client-id-onestep",
+    "krokedil/klarna-onsite-messaging": "dev-develop-check-client-id",
     "krokedil/settings-page": "1.3.4",
     "krokedil/sign-in-with-klarna": "^2.0.0"
   },

--- a/composer-dependencies.json
+++ b/composer-dependencies.json
@@ -4,8 +4,8 @@
     "krokedil/wp-api": "^1.0",
     "krokedil/woocommerce": "^1.8.0",
     "krokedil/support": "1.0.3",
-    "krokedil/klarna-express-checkout": "dev-develop-check-client-id-onestep",
-    "krokedil/klarna-onsite-messaging": "dev-develop-check-client-id",
+    "krokedil/klarna-express-checkout": "2.1.5",
+    "krokedil/klarna-onsite-messaging": "2.1.2",
     "krokedil/settings-page": "1.3.4",
     "krokedil/sign-in-with-klarna": "^2.0.0"
   },

--- a/composer-dependencies.lock
+++ b/composer-dependencies.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "695d440012523a80ff7dc351fc91003d",
+    "content-hash": "bff692f4761e9101e7379ef60c9e87a5",
     "packages": [
         {
             "name": "firebase/php-jwt",
@@ -71,16 +71,16 @@
         },
         {
             "name": "krokedil/klarna-express-checkout",
-            "version": "dev-develop-check-client-id-onestep",
+            "version": "2.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/krokedil/klarna-express-checkout.git",
-                "reference": "5c9a9ce1c7ca6f56ebd736a852034ba1cb16f365"
+                "reference": "3e1c080d4d651f77f3c06fa48f7fa5bd03cbdddb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/krokedil/klarna-express-checkout/zipball/5c9a9ce1c7ca6f56ebd736a852034ba1cb16f365",
-                "reference": "5c9a9ce1c7ca6f56ebd736a852034ba1cb16f365",
+                "url": "https://api.github.com/repos/krokedil/klarna-express-checkout/zipball/3e1c080d4d651f77f3c06fa48f7fa5bd03cbdddb",
+                "reference": "3e1c080d4d651f77f3c06fa48f7fa5bd03cbdddb",
                 "shasum": ""
             },
             "require": {
@@ -135,23 +135,23 @@
             ],
             "description": "A Klarna Express Checkout solution for WooCommerce",
             "support": {
-                "source": "https://github.com/krokedil/klarna-express-checkout/tree/develop-check-client-id-onestep",
+                "source": "https://github.com/krokedil/klarna-express-checkout/tree/2.1.5",
                 "issues": "https://github.com/krokedil/klarna-express-checkout/issues"
             },
-            "time": "2026-05-08T12:58:09+00:00"
+            "time": "2026-05-11T12:14:57+00:00"
         },
         {
             "name": "krokedil/klarna-onsite-messaging",
-            "version": "dev-develop-check-client-id",
+            "version": "2.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/krokedil/klarna-onsite-messaging.git",
-                "reference": "80bf0b13e616e8e5f0043053f91d25c59939eae5"
+                "reference": "8cd2f46884bad3c244e2787e0fe498213ac4a75c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/krokedil/klarna-onsite-messaging/zipball/80bf0b13e616e8e5f0043053f91d25c59939eae5",
-                "reference": "80bf0b13e616e8e5f0043053f91d25c59939eae5",
+                "url": "https://api.github.com/repos/krokedil/klarna-onsite-messaging/zipball/8cd2f46884bad3c244e2787e0fe498213ac4a75c",
+                "reference": "8cd2f46884bad3c244e2787e0fe498213ac4a75c",
                 "shasum": ""
             },
             "require": {
@@ -206,10 +206,10 @@
             ],
             "description": "Klarna On-Site Messaging for WooCommerce",
             "support": {
-                "source": "https://github.com/krokedil/klarna-onsite-messaging/tree/develop-check-client-id",
+                "source": "https://github.com/krokedil/klarna-onsite-messaging/tree/2.1.2",
                 "issues": "https://github.com/krokedil/klarna-onsite-messaging/issues"
             },
-            "time": "2026-05-08T13:04:34+00:00"
+            "time": "2026-05-11T12:21:02+00:00"
         },
         {
             "name": "krokedil/settings-page",
@@ -439,10 +439,7 @@
     "packages-dev": [],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": {
-        "krokedil/klarna-express-checkout": 20,
-        "krokedil/klarna-onsite-messaging": 20
-    },
+    "stability-flags": [],
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {

--- a/composer-dependencies.lock
+++ b/composer-dependencies.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7d97ca60c36d1cc69184ab22245d41bc",
+    "content-hash": "695d440012523a80ff7dc351fc91003d",
     "packages": [
         {
             "name": "firebase/php-jwt",
@@ -71,16 +71,16 @@
         },
         {
             "name": "krokedil/klarna-express-checkout",
-            "version": "2.1.4",
+            "version": "dev-develop-check-client-id-onestep",
             "source": {
                 "type": "git",
                 "url": "https://github.com/krokedil/klarna-express-checkout.git",
-                "reference": "4f08e228f46e04b149a6a9a1b49879bbb2f3440b"
+                "reference": "5c9a9ce1c7ca6f56ebd736a852034ba1cb16f365"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/krokedil/klarna-express-checkout/zipball/4f08e228f46e04b149a6a9a1b49879bbb2f3440b",
-                "reference": "4f08e228f46e04b149a6a9a1b49879bbb2f3440b",
+                "url": "https://api.github.com/repos/krokedil/klarna-express-checkout/zipball/5c9a9ce1c7ca6f56ebd736a852034ba1cb16f365",
+                "reference": "5c9a9ce1c7ca6f56ebd736a852034ba1cb16f365",
                 "shasum": ""
             },
             "require": {
@@ -135,23 +135,23 @@
             ],
             "description": "A Klarna Express Checkout solution for WooCommerce",
             "support": {
-                "source": "https://github.com/krokedil/klarna-express-checkout/tree/2.1.4",
+                "source": "https://github.com/krokedil/klarna-express-checkout/tree/develop-check-client-id-onestep",
                 "issues": "https://github.com/krokedil/klarna-express-checkout/issues"
             },
-            "time": "2026-04-21T08:48:57+00:00"
+            "time": "2026-05-08T12:58:09+00:00"
         },
         {
             "name": "krokedil/klarna-onsite-messaging",
-            "version": "2.1.1",
+            "version": "dev-develop-check-client-id",
             "source": {
                 "type": "git",
                 "url": "https://github.com/krokedil/klarna-onsite-messaging.git",
-                "reference": "7087c09d1a4f58dd99c8b4393eb3565f093218c0"
+                "reference": "80bf0b13e616e8e5f0043053f91d25c59939eae5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/krokedil/klarna-onsite-messaging/zipball/7087c09d1a4f58dd99c8b4393eb3565f093218c0",
-                "reference": "7087c09d1a4f58dd99c8b4393eb3565f093218c0",
+                "url": "https://api.github.com/repos/krokedil/klarna-onsite-messaging/zipball/80bf0b13e616e8e5f0043053f91d25c59939eae5",
+                "reference": "80bf0b13e616e8e5f0043053f91d25c59939eae5",
                 "shasum": ""
             },
             "require": {
@@ -206,10 +206,10 @@
             ],
             "description": "Klarna On-Site Messaging for WooCommerce",
             "support": {
-                "source": "https://github.com/krokedil/klarna-onsite-messaging/tree/2.1.1",
+                "source": "https://github.com/krokedil/klarna-onsite-messaging/tree/develop-check-client-id",
                 "issues": "https://github.com/krokedil/klarna-onsite-messaging/issues"
             },
-            "time": "2026-04-27T11:01:39+00:00"
+            "time": "2026-05-08T13:04:34+00:00"
         },
         {
             "name": "krokedil/settings-page",
@@ -439,7 +439,10 @@
     "packages-dev": [],
     "aliases": [],
     "minimum-stability": "dev",
-    "stability-flags": [],
+    "stability-flags": {
+        "krokedil/klarna-express-checkout": 20,
+        "krokedil/klarna-onsite-messaging": 20
+    },
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {

--- a/composer.lock
+++ b/composer.lock
@@ -9,16 +9,16 @@
     "packages-dev": [
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
-            "version": "v1.2.0",
+            "version": "v1.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/composer-installer.git",
-                "reference": "845eb62303d2ca9b289ef216356568ccc075ffd1"
+                "reference": "963f0c67bffde0eac41b56be71ac0e8ba132f0bd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/845eb62303d2ca9b289ef216356568ccc075ffd1",
-                "reference": "845eb62303d2ca9b289ef216356568ccc075ffd1",
+                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/963f0c67bffde0eac41b56be71ac0e8ba132f0bd",
+                "reference": "963f0c67bffde0eac41b56be71ac0e8ba132f0bd",
                 "shasum": ""
             },
             "require": {
@@ -101,7 +101,7 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-11-11T04:32:07+00:00"
+            "time": "2026-05-06T08:26:05+00:00"
         },
         {
             "name": "php-stubs/woocommerce-stubs",


### PR DESCRIPTION
Always register the script module, to prevent creating a PHP warning if a valid client id is not found.

This is an improvement of the error handling, but individual fixes for all boost feature packages is needed to avoid the console error that is now instead generated when a valid client id is not given.