### PR TITLE
Fix potential DivisionByZeroError refund error

### DIFF
--- a/.changelogs/2026-05-29-fix-division-by-zero
+++ b/.changelogs/2026-05-29-fix-division-by-zero
@@ -1,0 +1,4 @@
+Type: Fix
+Needs Documentation: no
+
+Fixed an issue where a partial refund could trigger a fatal `DivisionByZeroError` if the product quantity was left at `0`. Thank you [@blenardpazari](https://github.com/blenardpazari)!

--- a/src/OrderManagement/Request/Post/RequestPostRefund.php
+++ b/src/OrderManagement/Request/Post/RequestPostRefund.php
@@ -156,7 +156,7 @@ class RequestPostRefund extends RequestPost {
 
 					$reference           = $this->get_refund_item_reference( $item );
 					$name                = wp_strip_all_tags( $item->get_name() );
-					$quantity            = abs( $item->get_quantity() ?? 1 );
+					$quantity            = abs( $item->get_quantity() ) ?: 1;
 					$refund_price_amount = round( abs( $refund_order->get_line_subtotal( $item, false ) ) * 100 );
 					$total_discount      = $this->get_refund_item_discount_amount( $item, $separate_sales_tax );
 					$refund_tax_amount   = $separate_sales_tax ? 0 : abs( $this->get_refund_item_tax_amount( $item, $separate_sales_tax ) );


### PR DESCRIPTION
Fixes an issue where a partial refund can trigger a fatal `DivisionByZeroError` if the product quantity is left at `0`. Thank you [@blenardpazari](https://github.com/blenardpazari)!