### PR TITLE
Combine payment methods setting

### DIFF
--- a/.changelogs/2026-06-10-add-combine-payment-methods-setting
+++ b/.changelogs/2026-06-10-add-combine-payment-methods-setting
@@ -1,0 +1,4 @@
+Type: Feature
+Needs Documentation: yes
+
+Added a new "Combine payment methods" setting. When enabled, Klarna is displayed as a single payment method named "Pay with Klarna" in the checkout, and the customer can choose between the available Klarna payment options inside the Klarna widget.

--- a/assets/js/klarna-payments.js
+++ b/assets/js/klarna-payments.js
@@ -186,12 +186,14 @@ jQuery( function ( $ ) {
 
 						var options = {
 							container: klarna_payments_container_selector_id,
-							payment_method_category:
-								klarna_payments.getSelectedPaymentCategory() === "klarna_payments"
-									? ""
-									: klarna_payments.getSelectedPaymentCategory(),
 							// purchased_amount is used on the checkout page in any of Klarna payment methods that show a cost breakdown (the "Learn more" OSM widget).
 							purchase_amount: klarna_payments.cart_total,
+						}
+
+						// When the payment methods are combined into a single method, the category is omitted so the widget displays all payment options available in the Klarna session.
+						var payment_method_category = klarna_payments.getSelectedPaymentCategory()
+						if ( "klarna_payments" !== payment_method_category ) {
+							options.payment_method_category = payment_method_category
 						}
 
 						if ( fragments && fragments.kp_cart_total ) {
@@ -276,15 +278,17 @@ jQuery( function ( $ ) {
 
 			klarna_payments.authorization_response = {}
 
+			// The category must match the load() call, so it is omitted here as well when the payment methods are combined into a single method.
+			var options = {}
+			var payment_method_category = klarna_payments.getSelectedPaymentCategory()
+			if ( "klarna_payments" !== payment_method_category ) {
+				options.payment_method_category = payment_method_category
+			}
+
 			try {
 				Klarna.Payments.authorize(
 					address,
-					{
-						payment_method_category:
-							klarna_payments.getSelectedPaymentCategory() === "klarna_payments"
-								? ""
-								: klarna_payments.getSelectedPaymentCategory(),
-					},
+					options,
 					function ( response ) {
 						klarna_payments.authorization_response = response
 						$defer.resolve( response )

--- a/blocks/src/payment/KlarnaPayments.php
+++ b/blocks/src/payment/KlarnaPayments.php
@@ -81,7 +81,7 @@ class KlarnaPayments extends AbstractPaymentMethodType {
 		}
 
 		return array(
-			'title'            => 'Klarna',
+			'title'            => kp_is_combined_payment_methods_enabled() ? kp_get_combined_payment_method_title() : 'Klarna',
 			'description'      => $this->get_setting( 'description' ),
 			'iconurl'          => apply_filters( 'kp_blocks_logo', WC_KLARNA_PAYMENTS_PLUGIN_URL . '/assets/img/klarna-logo.svg' ),
 			'orderbuttonlabel' => WC_Klarna_Payments::get_pay_button_label(),

--- a/classes/admin/class-kp-form-fields.php
+++ b/classes/admin/class-kp-form-fields.php
@@ -412,7 +412,7 @@ class KP_Form_Fields {
 	 */
 	public static function get_kp_section_fields( $settings = array() ) {
 		$kp_section = array(
-			'general'              => array(
+			'general'                 => array(
 				'id'          => 'general',
 				'title'       => 'Klarna Payments',
 				/* translators: [merchant-facing]. */
@@ -426,7 +426,7 @@ class KP_Form_Fields {
 				),
 				'type'        => 'kp_section_start',
 			),
-			'enabled'              => array(
+			'enabled'                 => array(
 				/* translators: [merchant-facing]. */
 				'title'       => __( 'Enable/Disable', 'klarna-payments-for-woocommerce' ),
 				/* translators: [merchant-facing]. */
@@ -435,7 +435,7 @@ class KP_Form_Fields {
 				'description' => '',
 				'default'     => 'no',
 			),
-			'hide_what_is_klarna'  => array(
+			'hide_what_is_klarna'     => array(
 				/* translators: [merchant-facing]. */
 				'title'    => __( 'Hide "What is Klarna?" link', 'klarna-payments-for-woocommerce' ),
 				'type'     => 'checkbox',
@@ -444,7 +444,7 @@ class KP_Form_Fields {
 				'default'  => 'no',
 				'desc_tip' => true,
 			),
-			'float_what_is_klarna' => array(
+			'float_what_is_klarna'    => array(
 				/* translators: [merchant-facing]. */
 				'title'    => __( 'Float "What is Klarna?" link', 'klarna-payments-for-woocommerce' ),
 				'type'     => 'checkbox',
@@ -453,7 +453,7 @@ class KP_Form_Fields {
 				'default'  => 'yes',
 				'desc_tip' => false,
 			),
-			'send_product_urls'    => array(
+			'send_product_urls'       => array(
 				/* translators: [merchant-facing]. */
 				'title'    => __( 'Product URLs', 'klarna-payments-for-woocommerce' ),
 				'type'     => 'checkbox',
@@ -462,7 +462,7 @@ class KP_Form_Fields {
 				'default'  => 'yes',
 				'desc_tip' => true,
 			),
-			'add_to_email'         => array(
+			'add_to_email'            => array(
 				/* translators: [merchant-facing]. */
 				'title'    => __( 'Add Klarna URLs to order email', 'klarna-payments-for-woocommerce' ),
 				'type'     => 'checkbox',
@@ -471,7 +471,7 @@ class KP_Form_Fields {
 				'default'  => 'no',
 				'desc_tip' => false,
 			),
-			'customer_type'        => array(
+			'customer_type'           => array(
 				/* translators: [merchant-facing]. */
 				'title'       => __( 'Customer type', 'klarna-payments-for-woocommerce' ),
 				'type'        => 'select',
@@ -488,7 +488,16 @@ class KP_Form_Fields {
 				'default'     => 'b2c',
 				'desc_tip'    => true,
 			),
-			'checkout_flow'        => array(
+			'combine_payment_methods' => array(
+				/* translators: [merchant-facing]. */
+				'title'    => __( 'Combine payment methods', 'klarna-payments-for-woocommerce' ),
+				'type'     => 'checkbox',
+				/* translators: [merchant-facing]. */
+				'label'    => __( 'Display Klarna as a single payment method in the checkout. The customer can choose between the available Klarna payment options inside the Klarna widget.', 'klarna-payments-for-woocommerce' ),
+				'default'  => 'no',
+				'desc_tip' => true,
+			),
+			'checkout_flow'           => array(
 				/* translators: [merchant-facing]. */
 				'title'       => __( 'Checkout Flow', 'klarna-payments-for-woocommerce' ),
 				'type'        => 'select',
@@ -505,7 +514,7 @@ class KP_Form_Fields {
 				'default'     => 'popout',
 				'desc_tip'    => true,
 			),
-			'general_end'          => array(
+			'general_end'             => array(
 				'type'     => 'kp_section_end',
 				'previews' => array(
 					array(

--- a/classes/class-wc-gateway-klarna-payments.php
+++ b/classes/class-wc-gateway-klarna-payments.php
@@ -63,6 +63,15 @@ class WC_Gateway_Klarna_Payments extends WC_Payment_Gateway {
 	public $testmode;
 
 	/**
+	 * Whether the combined Klarna payment method is currently being rendered. Used to prevent the
+	 * payment method template override from recursing, since the gateway keeps its original id when
+	 * the payment methods are combined.
+	 *
+	 * @var bool
+	 */
+	public static $is_rendering_combined = false;
+
+	/**
 	 * Constructor
 	 */
 	public function __construct() {
@@ -355,7 +364,7 @@ class WC_Gateway_Klarna_Payments extends WC_Payment_Gateway {
 	public function override_kp_payment_option( $located, $template_name, $args ) {
 		if ( is_checkout() ) {
 			if ( 'checkout/payment-method.php' === $template_name ) {
-				if ( 'klarna_payments' === $args['gateway']->id ) {
+				if ( 'klarna_payments' === $args['gateway']->id && ! self::$is_rendering_combined ) {
 					$checkout_flow = $this->get_option( 'checkout_flow', 'popout' );
 					if ( 'redirect' !== $checkout_flow ) {
 						$located = untrailingslashit( plugin_dir_path( __DIR__ ) ) . '/templates/klarna-payments-categories.php';

--- a/includes/kp-functions.php
+++ b/includes/kp-functions.php
@@ -551,6 +551,35 @@ function kp_set_payment_method_title( $order, $klarna_place_order_response ) {
 }
 
 /**
+ * Whether the "Combine payment methods" setting is enabled, meaning Klarna should be displayed as a
+ * single payment method in the checkout instead of one payment method per Klarna payment category.
+ *
+ * @return bool
+ */
+function kp_is_combined_payment_methods_enabled() {
+	$settings = get_option( 'woocommerce_klarna_payments_settings', array() );
+
+	return 'yes' === ( $settings['combine_payment_methods'] ?? 'no' );
+}
+
+/**
+ * Get the title for the combined Klarna payment method displayed in the checkout.
+ *
+ * @return string
+ */
+function kp_get_combined_payment_method_title() {
+	/* translators: [customer-facing]. */
+	$title = __( 'Pay with Klarna', 'klarna-payments-for-woocommerce' );
+
+	/**
+	 * Filters the title of the combined Klarna payment method displayed in the checkout.
+	 *
+	 * @param string $title The combined Klarna payment method title.
+	 */
+	return apply_filters( 'wc_klarna_payments_combined_payment_method_title', $title );
+}
+
+/**
  * Whether HPOS is enabled.
  *
  * @return bool

--- a/templates/klarna-payments-categories.php
+++ b/templates/klarna-payments-categories.php
@@ -20,7 +20,30 @@ if ( is_array( $klarna_payment_categories ) ) {
 	$kp                 = $available_gateways['klarna_payments'];
 	$chosen_gateway     = $available_gateways[ array_key_first( $available_gateways ) ];
 
-	foreach ( apply_filters( 'wc_klarna_payments_available_payment_categories', $klarna_payment_categories ) as $klarna_payment_category ) {
+	$klarna_payment_categories = apply_filters( 'wc_klarna_payments_available_payment_categories', $klarna_payment_categories );
+
+	// If the payment methods should be combined, render a single payment method. The Klarna widget will let the customer choose between the available Klarna payment options.
+	if ( kp_is_combined_payment_methods_enabled() && ! empty( $klarna_payment_categories ) ) {
+		$first_klarna_payment_category = reset( $klarna_payment_categories );
+		if ( ! is_array( $first_klarna_payment_category ) ) {
+			$first_klarna_payment_category = json_decode( wp_json_encode( $first_klarna_payment_category ), true );
+		}
+
+		$kp->title = kp_get_combined_payment_method_title();
+		$kp->icon  = $first_klarna_payment_category['asset_urls']['standard'] ?? null;
+
+		// For "Linear Checkout for WooCommerce by Cartimize" to work, we cannot output any HTML.
+		if ( did_action( 'cartimize_get_payment_methods_html' ) === 0 ) {
+			// Since the gateway keeps its original id, the render guard prevents the template override from recursing into this template again.
+			WC_Gateway_Klarna_Payments::$is_rendering_combined = true;
+			wc_get_template( 'checkout/payment-method.php', array( 'gateway' => $kp ) );
+			WC_Gateway_Klarna_Payments::$is_rendering_combined = false;
+		}
+
+		return;
+	}
+
+	foreach ( $klarna_payment_categories as $klarna_payment_category ) {
 		if ( ! is_array( $klarna_payment_category ) ) {
 			$klarna_payment_category = json_decode( wp_json_encode( $klarna_payment_category ), true );
 		}


### PR DESCRIPTION
I have tested placing orders using both the API keys that split the purchase into three different payment methods, and a set of keys that already showed Klarna as a payment option.