### PR TITLE
Check if reached checkout through the KEC flow

### DIFF
--- a/.changelogs/2026-06-24-fix-two-step-redirect
+++ b/.changelogs/2026-06-24-fix-two-step-redirect
@@ -1,0 +1,4 @@
+Type: Fix
+Needs Documentation: no
+
+The Two-Step Klarna Express Checkout flow now works as expected when the redirect checkout flow is used.

--- a/classes/class-wc-gateway-klarna-payments.php
+++ b/classes/class-wc-gateway-klarna-payments.php
@@ -410,7 +410,11 @@ class WC_Gateway_Klarna_Payments extends WC_Payment_Gateway {
 		$checkout_flow = $this->get_option( 'checkout_flow', 'popout' );
 
 		if ( 'redirect' === $checkout_flow ) {
-			return $this->process_blocks_order( $order );
+			// If the user arrived via the KEC two-step flow, skip the HPP and process the order directly.
+			$kec_client_token = KrokedilKlarnaPaymentsDeps\Krokedil\KlarnaExpressCheckout\Session::get_client_token();
+			if ( empty( $kec_client_token ) ) {
+				return $this->process_blocks_order( $order );
+			}
 		}
 
 		return $this->process_checkout_order( $order );


### PR DESCRIPTION
The Two-Step Klarna Express Checkout flow now works as expected when the redirect checkout flow is used.