### PR TITLE
Fix refund processing for zero-value refund lines.

### DIFF
--- a/.changelogs/2026-07-15-fix-zero-value-refund-lines
+++ b/.changelogs/2026-07-15-fix-zero-value-refund-lines
@@ -1,0 +1,3 @@
+Fix refund processing failure when refund contains zero-value line items.
+
+Prevent DivisionByZeroError in Klarna refund line builder when WooCommerce taxes are disabled and a refunded item has a total of 0.

--- a/.changelogs/2026-07-15-fix-zero-value-refund-lines
+++ b/.changelogs/2026-07-15-fix-zero-value-refund-lines
@@ -1,3 +1,4 @@
-Fix refund processing failure when refund contains zero-value line items.
+Type: Fix
+Needs Documentation: no
 
-Prevent DivisionByZeroError in Klarna refund line builder when WooCommerce taxes are disabled and a refunded item has a total of 0.
+Refunds that include zero-value order lines are now processed correctly, preventing a division-by-zero error when taxes are disabled.

--- a/src/OrderManagement/Request/Post/RequestPostRefund.php
+++ b/src/OrderManagement/Request/Post/RequestPostRefund.php
@@ -158,7 +158,7 @@ class RequestPostRefund extends RequestPost {
 
 					$reference           = $this->get_refund_item_reference( $item );
 					$name                = wp_strip_all_tags( $item->get_name() );
-					$quantity            = abs( $item->get_quantity() ) ?: 1;
+					$quantity            = abs( $item->get_quantity() ) ?: 1; // phpcs:ignore Universal.Operators.DisallowShortTernary.Found -- Short ternary is used intentionally and correctly here to set a default quantity of 1 if the quantity is 0 or not set.
 					$refund_price_amount = round( abs( $refund_order->get_line_subtotal( $item, false ) ) * 100 );
 					$total_discount      = $this->get_refund_item_discount_amount( $item, $separate_sales_tax );
 					$refund_tax_amount   = $separate_sales_tax ? 0 : abs( $this->get_refund_item_tax_amount( $item, $separate_sales_tax ) );
@@ -193,7 +193,6 @@ class RequestPostRefund extends RequestPost {
 
 					$order_shipping_total    = round( $order->get_shipping_total() * 100 );
 					$order_shipping_tax      = round( $order->get_shipping_tax() * 100 );
-
 					$order_shipping_tax_rate = empty( $order_shipping_total ) ? 0 : round( ( $order_shipping_tax / $order_shipping_total ) * 10000 );
 
 					$type                = 'shipping_fee';

--- a/src/OrderManagement/Request/Post/RequestPostRefund.php
+++ b/src/OrderManagement/Request/Post/RequestPostRefund.php
@@ -124,6 +124,8 @@ class RequestPostRefund extends RequestPost {
 				foreach ( $refunded_items as $item ) {
 					$product = wc_get_product( $item->get_product_id() );
 
+					$order_line_tax_rate = 0;
+
 					/**
 					 * Get the order line total from order for calculation.
 					 *
@@ -135,7 +137,7 @@ class RequestPostRefund extends RequestPost {
 							$order_line_tax      = round( ( $order->get_line_tax( $order_item ) * 100 ) );
 							$tax_rates           = \WC_Tax::get_base_tax_rates( $order_item->get_tax_class() );
 							$first_tax_rate      = reset( $tax_rates );
-							$order_line_tax_rate = ( 0 !== $order_line_tax && 0 !== $order_line_total ) ? ( isset( $first_tax_rate['rate'] ) ? $first_tax_rate['rate'] * 100 : round( ( $order_line_tax / $order_line_total ) * 100 * 100 ) ) : 0;
+							$order_line_tax_rate = ( $order_line_tax && $order_line_total ) ? ( isset( $first_tax_rate['rate'] ) ? $first_tax_rate['rate'] * 100 : round( ( $order_line_tax / $order_line_total ) * 100 * 100 ) ) : 0;
 						}
 					}
 
@@ -156,7 +158,7 @@ class RequestPostRefund extends RequestPost {
 
 					$reference           = $this->get_refund_item_reference( $item );
 					$name                = wp_strip_all_tags( $item->get_name() );
-					$quantity            = abs( $item->get_quantity() ) ?: 1; // phpcs:ignore Universal.Operators.DisallowShortTernary.Found -- Short ternary is used intentionally and correctly here to set a default quantity of 1 if the quantity is 0 or not set.
+					$quantity            = abs( $item->get_quantity() ) ?: 1;
 					$refund_price_amount = round( abs( $refund_order->get_line_subtotal( $item, false ) ) * 100 );
 					$total_discount      = $this->get_refund_item_discount_amount( $item, $separate_sales_tax );
 					$refund_tax_amount   = $separate_sales_tax ? 0 : abs( $this->get_refund_item_tax_amount( $item, $separate_sales_tax ) );
@@ -191,7 +193,8 @@ class RequestPostRefund extends RequestPost {
 
 					$order_shipping_total    = round( $order->get_shipping_total() * 100 );
 					$order_shipping_tax      = round( $order->get_shipping_tax() * 100 );
-					$order_shipping_tax_rate = 0 === $order_shipping_total ? 0 : round( ( $order_shipping_tax / $order_shipping_total ) * 10000 );
+
+					$order_shipping_tax_rate = empty( $order_shipping_total ) ? 0 : round( ( $order_shipping_tax / $order_shipping_total ) * 10000 );
 
 					$type                = 'shipping_fee';
 					$reference           = $shipping_item->get_method_id() . ':' . $shipping_item->get_instance_id();


### PR DESCRIPTION
# Fix refund failure when processing zero-value refund lines

## Issue

Refund requests containing zero-value line items can fail with a fatal error during the Klarna refund flow.

Example scenario:

- WooCommerce order contains a free item (`line total = 0`)
- The item is included in the refund request
- WooCommerce taxes are disabled
- Klarna refund line builder tries to calculate the tax rate
- The calculation results in a division by zero

Error:

```text
DivisionByZeroError: Division by zero
```

This causes the WooCommerce refund endpoint to return HTTP 500.

---

## Root cause

The issue is caused by strict zero comparisons in `RequestPostRefund.php`.

Current logic:

```php
0 !== $order_line_total
```

However, `$order_line_total` is calculated using `round()`, which returns a float value (`0.0`).

Because PHP strict comparison checks both value and type:

```php
0 !== 0.0 // true
```

the zero guard is bypassed and the code continues with the division:

```php
$order_line_tax / $order_line_total
```

Resulting in:

```text
0.0 / 0.0
```

which throws:

```text
DivisionByZeroError
```

---

## Changes applied

### 1. Handle zero-value refund line items correctly

Changed the zero check from:

```php
0 !== $order_line_tax && 0 !== $order_line_total
```

to:

```php
$order_line_tax && $order_line_total
```

This correctly handles both integer and float zero values.

---

### 2. Fix zero-cost shipping calculation

Updated the shipping tax calculation guard to correctly handle zero shipping totals.

Changed from:

```php
0 === $order_shipping_total
```

to:

```php
empty( $order_shipping_total )
```

This prevents the same division-by-zero scenario for zero-cost shipping lines.

---

### 3. Initialize refund line tax rate

Initialized `$order_line_tax_rate` with a default value before processing refund lines.

This prevents undefined values in edge cases where a refunded product no longer matches an existing order item.

---

## Validation

The fix was tested with a WooCommerce refund scenario containing:

- A normal refundable product line
- A zero-value line item
- WooCommerce taxes disabled

### Before the fix

- `DivisionByZeroError`
- Refund processing failed
- WooCommerce REST API returned HTTP 500

### After the fix

- Refund payload generated successfully
- Zero-value line items are handled correctly
- `tax_rate` is set to `0`
- No fatal errors occur

Example generated refund line:

```json
{
  "name": "Paper bag",
  "quantity": 1,
  "unit_price": 0,
  "tax_rate": 0,
  "total_amount": 0
}
```

---

## Why this fix is needed

Zero-value refund lines are valid WooCommerce refund scenarios, for example:

- Free promotional items
- Gift items
- Products with a 100% discount
- Zero-cost order lines

These cases should not cause the refund flow to fail.

The plugin should safely handle these refund structures instead of generating a fatal error.

---

## Related issue

Automatic Klarna refunds were failing because WooCommerce returned HTTP 500 when processing refunds containing zero-value line items.

This fix prevents the refund failure while keeping the existing refund behavior unchanged.