### PR TITLE
Custom capture status setting

### DIFF
--- a/.changelogs/2026-08-07-capture-status-setting
+++ b/.changelogs/2026-08-07-capture-status-setting
@@ -1,0 +1,4 @@
+Type: Enhancement
+Needs Documentation: no
+
+Added support for selecting a custom WooCommerce order status to trigger Klarna order capture.

--- a/src/OrderManagement.php
+++ b/src/OrderManagement.php
@@ -118,6 +118,7 @@ class OrderManagement {
 
 		$report_about = array(
 			array( 'id' => 'kom_auto_capture' ),
+			array( 'id' => 'kom_capture_status' ),
 			array( 'id' => 'kom_auto_cancel' ),
 			array( 'id' => 'kom_auto_update' ),
 			array( 'id' => 'kom_auto_order_sync' ),
@@ -129,8 +130,8 @@ class OrderManagement {
 		// Cancel order.
 		add_action( 'woocommerce_order_status_cancelled', array( $this, 'cancel_klarna_order' ) );
 
-		// Capture an order.
-		add_action( 'woocommerce_order_status_completed', array( $this, 'capture_klarna_order' ) );
+		// Capture an order when it reaches the configured capture trigger status.
+		add_action( 'woocommerce_order_status_changed', array( $this, 'maybe_capture_klarna_order' ), 10, 3 );
 
 		// Update an order.
 		add_action( 'woocommerce_saved_order_items', array( $this, 'update_klarna_order_items' ), 10, 2 );
@@ -410,6 +411,24 @@ class OrderManagement {
 		}
 
 		return true;
+	}
+
+	/**
+	 * Captures a Klarna order if the order just transitioned to the configured capture trigger status.
+	 *
+	 * @param int    $order_id Order ID.
+	 * @param string $status_from Previous order status.
+	 * @param string $status_to New order status.
+	 *
+	 * @return void
+	 */
+	public function maybe_capture_klarna_order( $order_id, $status_from, $status_to ) {
+		$options        = $this->settings->get_settings( $order_id );
+		$capture_status = ! empty( $options['kom_capture_status'] ) ? $options['kom_capture_status'] : 'completed';
+
+		if ( $status_to === $capture_status ) {
+			$this->capture_klarna_order( $order_id );
+		}
 	}
 
 	/**

--- a/src/OrderManagement.php
+++ b/src/OrderManagement.php
@@ -131,7 +131,7 @@ class OrderManagement {
 		add_action( 'woocommerce_order_status_cancelled', array( $this, 'cancel_klarna_order' ) );
 
 		// Capture an order when it reaches the configured capture trigger status.
-		add_action( 'woocommerce_order_status_changed', array( $this, 'maybe_capture_klarna_order' ), 10, 3 );
+		add_action( 'woocommerce_order_status_changed', array( $this, 'maybe_capture_klarna_order' ), 10, 4 );
 
 		// Update an order.
 		add_action( 'woocommerce_saved_order_items', array( $this, 'update_klarna_order_items' ), 10, 2 );
@@ -416,13 +416,14 @@ class OrderManagement {
 	/**
 	 * Captures a Klarna order if the order just transitioned to the configured capture trigger status.
 	 *
-	 * @param int    $order_id Order ID.
-	 * @param string $status_from Previous order status.
-	 * @param string $status_to New order status.
+	 * @param int       $order_id Order ID.
+	 * @param string    $status_from Previous order status.
+	 * @param string    $status_to New order status.
+	 * @param \WC_Order $order The WooCommerce order object.
 	 *
 	 * @return void
 	 */
-	public function maybe_capture_klarna_order( $order_id, $status_from, $status_to ) {
+	public function maybe_capture_klarna_order( $order_id, $status_from, $status_to, $order ) {
 		$options        = $this->settings->get_settings( $order_id );
 		$capture_status = ! empty( $options['kom_capture_status'] ) ? $options['kom_capture_status'] : 'completed';
 

--- a/src/OrderManagement.php
+++ b/src/OrderManagement.php
@@ -423,7 +423,7 @@ class OrderManagement {
 	 *
 	 * @return void
 	 */
-	public function maybe_capture_klarna_order( $order_id, $status_from, $status_to, $order ) {
+	public function maybe_capture_klarna_order( $order_id, $status_from, $status_to, $order ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- Kept to match the woocommerce_order_status_changed hook.
 		$options        = $this->settings->get_settings( $order_id );
 		$capture_status = ! empty( $options['kom_capture_status'] ) ? $options['kom_capture_status'] : 'completed';
 

--- a/src/OrderManagement/Settings.php
+++ b/src/OrderManagement/Settings.php
@@ -28,6 +28,7 @@ class Settings {
 			get_option( 'kom_settings', array() ),
 			array(
 				'kom_auto_capture'       => 'yes',
+				'kom_capture_status'     => 'completed',
 				'kom_auto_cancel'        => 'yes',
 				'kom_auto_update'        => 'yes',
 				'kom_auto_order_sync'    => 'yes',
@@ -41,11 +42,20 @@ class Settings {
 		);
 
 		$settings['kom_auto_capture'] = array(
-			'title'   => 'On order completion',
+			'title'   => 'On order status change',
 			'type'    => 'checkbox',
 			'default' => $default_values['kom_auto_capture'],
 			/* translators: [merchant-facing]. */
-			'label'   => __( 'Activate Klarna order automatically when WooCommerce order is marked complete.', 'klarna-payments-for-woocommerce' ),
+			'label'   => __( 'Activate Klarna order automatically when the WooCommerce order reaches the status selected below.', 'klarna-payments-for-woocommerce' ),
+		);
+
+		$settings['kom_capture_status'] = array(
+			'title'    => 'Capture order status',
+			'type'     => 'select',
+			'options'  => $this->get_order_status_options(),
+			'default'  => $default_values['kom_capture_status'],
+			/* translators: [merchant-facing]. */
+			'desc_tip' => __( 'The order status that should trigger a Klarna capture request.', 'klarna-payments-for-woocommerce' ),
 		);
 
 		$settings['kom_auto_cancel'] = array(
@@ -81,6 +91,21 @@ class Settings {
 		);
 
 		return $settings;
+	}
+
+	/**
+	 * Get the WooCommerce order statuses available for the capture trigger select field.
+	 *
+	 * @return array
+	 */
+	private function get_order_status_options() {
+		$options = array();
+
+		foreach ( wc_get_order_statuses() as $slug => $label ) {
+			$options[ str_replace( 'wc-', '', $slug ) ] = $label;
+		}
+
+		return $options;
 	}
 
 	/**

--- a/src/OrderManagement/Settings.php
+++ b/src/OrderManagement/Settings.php
@@ -99,9 +99,14 @@ class Settings {
 	 * @return array
 	 */
 	private function get_order_status_options() {
-		$options = array();
+		$options           = array();
+		$wc_order_statuses = wc_get_order_statuses();
 
-		foreach ( wc_get_order_statuses() as $slug => $label ) {
+		unset( $wc_order_statuses['wc-pending'] );
+		unset( $wc_order_statuses['wc-refunded'] );
+		unset( $wc_order_statuses['wc-failed'] );
+
+		foreach ( $wc_order_statuses as $slug => $label ) {
 			$options[ str_replace( 'wc-', '', $slug ) ] = $label;
 		}
 


### PR DESCRIPTION
Adds support for selecting a custom WooCommerce order status to trigger the Klarna order capture.