### PR TITLE
Fix pay for order potential fatal error

### DIFF
--- a/.changelogs/2026-08-07-pay-for-order-error-fix
+++ b/.changelogs/2026-08-07-pay-for-order-error-fix
@@ -1,0 +1,4 @@
+Type: Fix
+Needs Documentation: no
+
+Fixed a fatal error on the order-pay page that occurred when the order no longer existed.

--- a/classes/class-kp-assets.php
+++ b/classes/class-kp-assets.php
@@ -196,9 +196,12 @@ class KP_Assets {
 		$pay_for_order = kp_is_order_pay_page();
 		$order_id      = $pay_for_order ? absint( get_query_var( 'order-pay', 0 ) ) : null;
 		$order_key     = null;
+
 		if ( ! empty( $order_id ) ) {
-			$order     = wc_get_order( $order_id );
-			$order_key = $order->get_order_key();
+			$order = wc_get_order( $order_id );
+			if ( ! empty( $order ) ) {
+				$order_key = $order->get_order_key();
+			}
 		}
 
 		$customer_type = klarna_get_customer_type( $settings['customer_type'] ?? 'b2c' );


### PR DESCRIPTION
Fixes a fatal error on the order-pay page that occurs when the order no longer exists: `CRITICAL Uncaught Error: Call to a member function get_order_key() on bool...`