### PR TITLE
Fix extra debug log setting not working

### DIFF
--- a/.changelogs/2026-08-10-fix-debug-logging
+++ b/.changelogs/2026-08-10-fix-debug-logging
@@ -1,0 +1,4 @@
+Type: Fix
+Needs Documentation: no
+
+Fixed an issue where setting Logging to "Yes (with extra debug data)" disabled the plugin's logging, instead of adding extra debug data to them.

--- a/klarna-payments-for-woocommerce.php
+++ b/klarna-payments-for-woocommerce.php
@@ -308,7 +308,7 @@ if ( ! class_exists( 'WC_Klarna_Payments' ) ) {
 			$this->siwk                    = new SignInWithKlarna( $settings );
 			$this->interoperability_token  = new KP_Interoperability_Token();
 			$this->order_management        = new OrderManagement();
-			$this->logger                  = new Logger( 'klarna_payments', wc_string_to_bool( $settings['logging'] ?? false ) );
+			$this->logger                  = new Logger( 'klarna_payments', 'no' !== ( $settings['logging'] ?? 'no' ) );
 			Compatibility::register();
 
 			// Includes the selectable, and checkbox settings, but excludes those whose title is empty. The 'kp_section_start' will appear as a section header in the system report.


### PR DESCRIPTION
Fixes an issue where setting Logging to "Yes (with extra debug data)" disabled the plugin's logging, instead of adding extra debug data to them.