### PR TITLE
Fix OM conflict for refunds

### DIFF
--- a/.changelogs/2026-08-12-fix-om-conflict
+++ b/.changelogs/2026-08-12-fix-om-conflict
@@ -1,0 +1,4 @@
+Type: Fix
+Needs Documentation: no
+
+Resolved a compatibility conflict with the "Kustom Checkout for WooCommerce" plugin that could cause WooCommerce refund processing to fail when both plugins were active.

--- a/src/OrderManagement.php
+++ b/src/OrderManagement.php
@@ -547,9 +547,9 @@ class OrderManagement {
 	public function refund_klarna_order( $result, $order_id, $amount = null, $reason = '' ) {
 		$order = wc_get_order( $order_id );
 
-		// If the order was not paid using Klarna Payments, bail.
+		// If the order was not paid using Klarna Payments, return the original result.
 		if ( 'klarna_payments' !== $order->get_payment_method() ) {
-			return;
+			return $result;
 		}
 
 		// The merchant has disconnected the order from the order manager.


### PR DESCRIPTION
Resolves a compatibility conflict with the "Kustom Checkout for WooCommerce" plugin that could cause WooCommerce refund processing to fail when both plugins were active.