### PR TITLE
Use sentence case for "Klarna order management" in UI labels

### DIFF
--- a/src/OrderManagement.php
+++ b/src/OrderManagement.php
@@ -125,7 +125,7 @@ class OrderManagement {
 			array( 'id' => 'kom_force_full_capture' ),
 
 		);
-		$this->system_report = new SystemReport( 'klarna_payments', 'Klarna Order Management for WooCommerce', $report_about );
+		$this->system_report = new SystemReport( 'klarna_payments', 'Klarna order management for WooCommerce', $report_about );
 
 		// Cancel order.
 		add_action( 'woocommerce_order_status_cancelled', array( $this, 'cancel_klarna_order' ) );

--- a/src/OrderManagement/MetaBox.php
+++ b/src/OrderManagement/MetaBox.php
@@ -28,7 +28,7 @@ class MetaBox extends OrderMetabox {
 	 */
 	public function __construct( $order_management ) {
 		$this->order_management = $order_management;
-		parent::__construct( 'klarna-om', 'Klarna Order Management', 'klarna_payments' );
+		parent::__construct( 'klarna-om', 'Klarna order management', 'klarna_payments' );
 
 		add_action( 'add_meta_boxes', array( $this, 'kom_meta_box' ) );
 		add_action( 'woocommerce_process_shop_order_meta', array( $this, 'process_kom_actions' ), 45, 2 );

--- a/src/OrderManagement/Settings.php
+++ b/src/OrderManagement/Settings.php
@@ -37,7 +37,7 @@ class Settings {
 		);
 
 		$settings['kom'] = array(
-			'title' => 'Klarna Order Management',
+			'title' => 'Klarna order management',
 			'type'  => 'title',
 		);
 


### PR DESCRIPTION
Change the capitalization of "Klarna Order Management" to sentence case
("Klarna order management") in the settings section title, order metabox
title, and system report label.

This is a purely cosmetic text change — no functionality, hooks, option
keys, or IDs are affected. None of these strings are wrapped in
translation functions, so this has no impact on existing wordpress.org
translations. The two admin notices referencing the separate
"Klarna Order Management" plugin by its actual product name were left
unchanged.