### PR TITLE
Log clean-up & add log retention functionality

### DIFF
--- a/.changelogs/2026-09-04-log-retention
+++ b/.changelogs/2026-09-04-log-retention
@@ -1,0 +1,4 @@
+Type: Enhancement
+Needs Documentation: yes
+
+Added a Log retention setting with a wc_kp_log_retention_days filter, for how many days the plugin's log files are kept. A daily scheduled event now removes Klarna log files older than that period. Set the value to 0 to leave the cleanup to WooCommerce.

--- a/.changelogs/2026-09-04-mask-personal-data-in-logs
+++ b/.changelogs/2026-09-04-mask-personal-data-in-logs
@@ -1,0 +1,4 @@
+Type: Enhancement
+Needs Documentation: yes
+
+Cleaned up logs.

--- a/classes/admin/class-kp-form-fields.php
+++ b/classes/admin/class-kp-form-fields.php
@@ -333,6 +333,19 @@ class KP_Form_Fields {
 				),
 				'desc_tip'    => true,
 			),
+			'log_retention_days'       => array(
+				/* translators: [merchant-facing]. */
+				'title'             => __( 'Log retention', 'klarna-payments-for-woocommerce' ),
+				'type'              => 'number',
+				/* translators: [merchant-facing]. */
+				'description'       => __( 'How many days the Klarna log files are kept before they are deleted automatically. Set to 0 to leave the cleanup to WooCommerce.', 'klarna-payments-for-woocommerce' ),
+				'default'           => '30',
+				'desc_tip'          => true,
+				'custom_attributes' => array(
+					'min'  => '0',
+					'step' => '1',
+				),
+			),
 			'send_shopping_data_title' => array(
 				/* translators: [merchant-facing]. */
 				'title'       => __( 'Shopping data', 'klarna-payments-for-woocommerce' ),

--- a/classes/class-kp-ajax.php
+++ b/classes/class-kp-ajax.php
@@ -84,7 +84,7 @@ if ( ! class_exists( 'KP_AJAX' ) ) {
 						// If the intent is only 'tokenize', we should not proceed further as 'place_order' only allows 'buy_and_tokenize' intent.
 						wp_send_json_success( $order->get_checkout_order_received_url() );
 					} else {
-						KP_Logger::log( sprintf( '[AJAX]: Order ID: %s. Auth token: %s. %s', $order->get_id(), $auth_token, $recurring_token->get_error_message() ) );
+						KP_Logger::log( sprintf( '[AJAX]: Order ID: %s. Auth token: %s. %s', $order->get_id(), '[REDACTED]', $recurring_token->get_error_message() ) );
 						wp_send_json_error( 'customer_token_failed' );
 					}
 				}

--- a/classes/class-kp-ajax.php
+++ b/classes/class-kp-ajax.php
@@ -84,7 +84,7 @@ if ( ! class_exists( 'KP_AJAX' ) ) {
 						// If the intent is only 'tokenize', we should not proceed further as 'place_order' only allows 'buy_and_tokenize' intent.
 						wp_send_json_success( $order->get_checkout_order_received_url() );
 					} else {
-						KP_Logger::log( sprintf( '[AJAX]: Order ID: %s. Auth token: %s. %s', $order->get_id(), '[REDACTED]', $recurring_token->get_error_message() ) );
+						KP_Logger::log( sprintf( '[AJAX]: Order ID: %s. Auth token: %s. %s', $order->get_id(), KP_Logger::REDACTED, $recurring_token->get_error_message() ) );
 						wp_send_json_error( 'customer_token_failed' );
 					}
 				}

--- a/classes/class-kp-callbacks.php
+++ b/classes/class-kp-callbacks.php
@@ -151,7 +151,7 @@ class KP_Callbacks {
 					/* translators: [merchant-facing]. */
 					$order->add_order_note( __( 'Failed to create a recurring token when returning from the hosted payment page.', 'klarna-payments-for-woocommerce' ) . $recurring_token->get_error_message() );
 
-					KP_Logger::log( sprintf( '[AJAX]: Order ID: %s. Auth token: %s. %s', $order->get_id(), $auth_token, $recurring_token->get_error_message() ) );
+					KP_Logger::log( sprintf( '[AJAX]: Order ID: %s. Auth token: %s. %s', $order->get_id(), '[REDACTED]', $recurring_token->get_error_message() ) );
 				}
 
 				// If the intent is only 'tokenize', we should not proceed further as 'place_order' only allows 'buy_and_tokenize' intent.

--- a/classes/class-kp-callbacks.php
+++ b/classes/class-kp-callbacks.php
@@ -151,7 +151,7 @@ class KP_Callbacks {
 					/* translators: [merchant-facing]. */
 					$order->add_order_note( __( 'Failed to create a recurring token when returning from the hosted payment page.', 'klarna-payments-for-woocommerce' ) . $recurring_token->get_error_message() );
 
-					KP_Logger::log( sprintf( '[AJAX]: Order ID: %s. Auth token: %s. %s', $order->get_id(), '[REDACTED]', $recurring_token->get_error_message() ) );
+					KP_Logger::log( sprintf( '[AJAX]: Order ID: %s. Auth token: %s. %s', $order->get_id(), KP_Logger::REDACTED, $recurring_token->get_error_message() ) );
 				}
 
 				// If the intent is only 'tokenize', we should not proceed further as 'place_order' only allows 'buy_and_tokenize' intent.

--- a/classes/class-kp-logger.php
+++ b/classes/class-kp-logger.php
@@ -14,6 +14,13 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class KP_Logger {
 	/**
+	 * The value written to the log in place of data that is masked.
+	 *
+	 * @var string
+	 */
+	const REDACTED = '[REDACTED]';
+
+	/**
 	 * Log message string
 	 *
 	 * @var string $log

--- a/classes/class-kp-logger.php
+++ b/classes/class-kp-logger.php
@@ -203,7 +203,13 @@ class KP_Logger {
 		$expired_before = time() - ( $days * DAY_IN_SECONDS );
 
 		foreach ( (array) glob( trailingslashit( WC_LOG_DIR ) . 'klarna_payments-*.log' ) as $file ) {
-			if ( is_file( $file ) && filemtime( $file ) < $expired_before ) {
+			if ( ! is_file( $file ) ) {
+				continue;
+			}
+
+			// A file whose age cannot be read is kept, rather than assumed to be expired.
+			$modified_at = filemtime( $file );
+			if ( false !== $modified_at && $modified_at < $expired_before ) {
 				wp_delete_file( $file );
 			}
 		}

--- a/classes/class-kp-logger.php
+++ b/classes/class-kp-logger.php
@@ -21,6 +21,13 @@ class KP_Logger {
 	const REDACTED = '[REDACTED]';
 
 	/**
+	 * The value written to the log in place of a credential that was expected but absent.
+	 *
+	 * @var string
+	 */
+	const MISSING = '[MISSING]';
+
+	/**
 	 * Log message string
 	 *
 	 * @var string $log

--- a/classes/class-kp-logger.php
+++ b/classes/class-kp-logger.php
@@ -51,7 +51,66 @@ class KP_Logger {
 			$request_body            = json_decode( $data['request']['body'], true );
 			$data['request']['body'] = $request_body;
 		}
-		return $data;
+		return self::redact( $data );
+	}
+
+	/**
+	 * Returns the payload keys whose values are masked before a log entry is written.
+	 *
+	 * @return array
+	 */
+	public static function get_redacted_fields() {
+		/**
+		 * Filters the payload keys that are masked before a log entry is written.
+		 *
+		 * @param array $fields The payload keys to mask.
+		 */
+		return apply_filters(
+			'wc_kp_log_redacted_fields',
+			array(
+				'given_name',
+				'family_name',
+				'organization_name',
+				'attention',
+				'email',
+				'phone',
+				'street_address',
+				'street_address2',
+				'date_of_birth',
+				'national_identification_number',
+				'klarna_access_token',
+			)
+		);
+	}
+
+	/**
+	 * Masks personal data in a log payload.
+	 *
+	 * @param mixed      $data The log payload, or a branch of it.
+	 * @param array|null $fields The keys to mask. Resolved once at the top of the recursion.
+	 * @return mixed
+	 */
+	public static function redact( $data, $fields = null ) {
+		if ( ! is_array( $data ) && ! is_object( $data ) ) {
+			return $data;
+		}
+
+		$fields = null === $fields ? self::get_redacted_fields() : $fields;
+
+		// Clone, so redacting a decoded response body cannot mutate an object the caller still uses.
+		$redacted = is_object( $data ) ? clone $data : $data;
+
+		foreach ( $data as $key => $value ) {
+			$value = in_array( $key, $fields, true ) && ! empty( $value ) ? self::REDACTED : self::redact( $value, $fields );
+
+			if ( is_object( $redacted ) ) {
+				$redacted->{$key} = $value;
+			} else {
+				$redacted[ $key ] = $value;
+			}
+		}
+
+		return $redacted;
 	}
 
 	/**
@@ -90,5 +149,56 @@ class KP_Logger {
 	 */
 	public static function get_stack() {
 		return wp_debug_backtrace_summary( __CLASS__, 3, false ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions -- Used for logging, not display.
+	}
+
+	/**
+	 * The number of days this plugin's log files are kept.
+	 *
+	 * @return int Zero if the merchant has opted out, leaving the files to WooCommerce's own cleanup.
+	 */
+	public static function get_retention_days() {
+		$kp_settings = get_option( 'woocommerce_klarna_payments_settings', array() );
+
+		/**
+		 * Filters how many days the Klarna log files are kept before they are deleted.
+		 *
+		 * @param int $days The retention period in days. Zero disables this plugin's own cleanup.
+		 */
+		return max( 0, (int) apply_filters( 'wc_kp_log_retention_days', $kp_settings['log_retention_days'] ?? 30 ) );
+	}
+
+	/**
+	 * Makes sure the log files are cleaned up daily.
+	 *
+	 * @return void
+	 */
+	public static function schedule_cleanup() {
+		if ( ! is_admin() && ! wp_doing_cron() && ! defined( 'WP_CLI' ) ) {
+			return;
+		}
+
+		if ( ! wp_next_scheduled( 'kp_cleanup_logs' ) ) {
+			wp_schedule_event( time() + HOUR_IN_SECONDS, 'daily', 'kp_cleanup_logs' );
+		}
+	}
+
+	/**
+	 * Deletes this plugin's expired log files.
+	 *
+	 * @return void
+	 */
+	public static function cleanup_logs() {
+		$days = self::get_retention_days();
+		if ( 0 === $days || ! defined( 'WC_LOG_DIR' ) ) {
+			return;
+		}
+
+		$expired_before = time() - ( $days * DAY_IN_SECONDS );
+
+		foreach ( (array) glob( trailingslashit( WC_LOG_DIR ) . 'klarna_payments-*.log' ) as $file ) {
+			if ( is_file( $file ) && filemtime( $file ) < $expired_before ) {
+				wp_delete_file( $file );
+			}
+		}
 	}
 }

--- a/classes/class-kp-logger.php
+++ b/classes/class-kp-logger.php
@@ -98,7 +98,7 @@ class KP_Logger {
 	 * @return mixed
 	 */
 	public static function redact( $data, $fields = null ) {
-		if ( ! is_array( $data ) && ! is_object( $data ) ) {
+		if ( ! is_array( $data ) && ! $data instanceof stdClass ) {
 			return $data;
 		}
 

--- a/classes/requests/class-kp-requests.php
+++ b/classes/requests/class-kp-requests.php
@@ -306,10 +306,10 @@ abstract class KP_Requests extends Request {
 
 		$arguments = $this->arguments;
 		if ( isset( $arguments['username'] ) ) {
-			$arguments['username'] = '[REDACTED]';
+			$arguments['username'] = KP_Logger::REDACTED;
 		}
 		if ( isset( $arguments['password'] ) ) {
-			$arguments['password'] = '[REDACTED]';
+			$arguments['password'] = KP_Logger::REDACTED;
 		}
 
 		KP_WC()->logger()->info(

--- a/classes/requests/class-kp-requests.php
+++ b/classes/requests/class-kp-requests.php
@@ -314,19 +314,21 @@ abstract class KP_Requests extends Request {
 
 		KP_WC()->logger()->info(
 			wp_json_encode(
-				array(
-					'type'        => $this->method,
-					'title'       => $this->log_title,
-					'arguments'   => $arguments,
-					'request'     => $request_args,
-					'request_url' => $request_url,
-					'response'    => array(
-					'body' => $response_body,
-					'code' => $code,
-					),
-					'timestamp'   => date( 'Y-m-d H:i:s' ),    // phpcs:ignore WordPress.DateTime.RestrictedFunctions -- Date is not used for display.
-				'stack'           => Logger::get_stack( $this->config['extended_debugging'] ),
-				'plugin_version'  => $this->config['plugin_version'],
+				KP_Logger::redact(
+					array(
+						'type'        => $this->method,
+						'title'       => $this->log_title,
+						'arguments'   => $arguments,
+						'request'     => $request_args,
+						'request_url' => $request_url,
+						'response'    => array(
+						'body' => $response_body,
+						'code' => $code,
+						),
+						'timestamp'   => date( 'Y-m-d H:i:s' ),    // phpcs:ignore WordPress.DateTime.RestrictedFunctions -- Date is not used for display.
+					'stack'           => Logger::get_stack( $this->config['extended_debugging'] ),
+					'plugin_version'  => $this->config['plugin_version'],
+					)
 				)
 			)
 		);

--- a/classes/requests/post/class-kp-unavailable-features.php
+++ b/classes/requests/post/class-kp-unavailable-features.php
@@ -136,7 +136,7 @@ class KP_Unavailable_Features extends KP_Requests_Post {
 	 * @return void
 	 */
 	protected function log_response( $response, $request_args, $request_url ) {
-		$this->arguments['api_password'] = '[REDACTED]';
+		$this->arguments['api_password'] = KP_Logger::REDACTED;
 		parent::log_response( $response, $request_args, $request_url );
 	}
 }

--- a/klarna-payments-for-woocommerce.php
+++ b/klarna-payments-for-woocommerce.php
@@ -267,6 +267,7 @@ if ( ! class_exists( 'WC_Klarna_Payments' ) ) {
 
 			add_action( 'kp_refresh_credential_capabilities', array( $this, 'refresh_credential_capabilities' ) );
 			add_action( 'kp_backfill_credential_capabilities', array( $this, 'refresh_credential_capabilities' ) );
+			add_action( 'kp_cleanup_logs', array( 'KP_Logger', 'cleanup_logs' ) );
 			register_deactivation_hook( __FILE__, array( $this, 'clear_scheduled_events' ) );
 		}
 
@@ -278,6 +279,7 @@ if ( ! class_exists( 'WC_Klarna_Payments' ) ) {
 		public function clear_scheduled_events() {
 			wp_clear_scheduled_hook( 'kp_refresh_credential_capabilities' );
 			wp_clear_scheduled_hook( 'kp_backfill_credential_capabilities' );
+			wp_clear_scheduled_hook( 'kp_cleanup_logs' );
 		}
 
 		/**
@@ -360,6 +362,7 @@ if ( ! class_exists( 'WC_Klarna_Payments' ) ) {
 			$this->plugin_features->init_features();
 
 			$this->schedule_credential_capabilities_refresh();
+			KP_Logger::schedule_cleanup();
 		}
 
 		/**

--- a/src/OrderManagement/Request/Request.php
+++ b/src/OrderManagement/Request/Request.php
@@ -357,7 +357,7 @@ abstract class Request {
 		foreach ( $request_args['headers'] as $header => $value ) {
 			if ( 'authorization' === strtolower( $header ) ) {
 				// If it is longer than 15 char., it most likely has a token. This is an assumption that is safe even if it is wrong.
-				$request_args['headers'][ $header ] = strlen( $value ) > 15 ? '[REDACTED]' : '[MISSING]';
+				$request_args['headers'][ $header ] = strlen( $value ) > 15 ? \KP_Logger::REDACTED : \KP_Logger::MISSING;
 				break;
 			}
 		}


### PR DESCRIPTION
- Cleans up logs
- Adds a setting and filter `wc_kp_log_retention_days` for how many days Klarna for WooCommerce logs should be retained; a scheduled daily check of the retention period is registered.